### PR TITLE
Improve initdb for openldap_database type

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -183,14 +183,16 @@ Puppet::Type.
     t << "objectClass: dcObject\n" if resource[:suffix].start_with?('dc=')
     t << "objectClass: organization\n"
     t << "dc: #{resource[:suffix].split(%r{,?dc=}).delete_if(&:empty?)[0]}\n" if resource[:suffix].start_with?('dc=')
-    t << "o: #{resource[:suffix].split(%r{,?dc=}).delete_if(&:empty?).join('.')}\n" if resource[:suffix].start_with?('dc=')
-    t << "\n"
-    t << "dn: cn=admin,#{resource[:suffix]}\n"
-    t << "objectClass: simpleSecurityObject\n" if resource[:rootpw]
-    t << "objectClass: organizationalRole\n"
-    t << "cn: admin\n"
-    t << "description: LDAP administrator\n"
-    t << "userPassword: #{resource[:rootpw]}\n" if resource[:rootpw]
+    t << "o: #{resource[:organization]}\n" if resource[:organization]
+    if resource[:rootdn]
+      t << "\n"
+      t << "dn: #{resource[:rootdn]}\n"
+      t << "objectClass: simpleSecurityObject\n" if resource[:rootpw]
+      t << "objectClass: organizationalRole\n"
+      t << "cn: #{resource[:rootdn].split(/,|=/)[1]}\n"
+      t << "description: LDAP administrator\n"
+      t << "userPassword: #{resource[:rootpw]}\n" if resource[:rootpw]
+    end
     t.close
     Puppet.debug(IO.read(t.path))
     begin

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -189,7 +189,7 @@ Puppet::Type.
       t << "dn: #{resource[:rootdn]}\n"
       t << "objectClass: simpleSecurityObject\n" if resource[:rootpw]
       t << "objectClass: organizationalRole\n"
-      t << "cn: #{resource[:rootdn].split(/,|=/)[1]}\n"
+      t << "cn: #{resource[:rootdn].split(%r{,|=})[1]}\n"
       t << "description: LDAP administrator\n"
       t << "userPassword: #{resource[:rootpw]}\n" if resource[:rootpw]
     end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -152,11 +152,11 @@ Puppet::Type.newtype(:openldap_database) do
   end
 
   newparam(:organization) do
-    desc "Organization name used when initdb is true"
+    desc 'Organization name used when initdb is true'
 
     defaultto do
       if @resource[:suffix].start_with?('dc=')
-        @resource[:suffix].split(/,?dc=/).delete_if { |c| c.empty? }.join('.')
+        @resource[:suffix].split(/,?dc=/).delete_if(&:empty?).join('.')
       end
     end
   end

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -151,6 +151,16 @@ Puppet::Type.newtype(:openldap_database) do
     end
   end
 
+  newparam(:organization) do
+    desc "Organization name used when initdb is true"
+
+    defaultto do
+      if @resource[:suffix].start_with?('dc=')
+        @resource[:suffix].split(/,?dc=/).delete_if { |c| c.empty? }.join('.')
+      end
+    end
+  end
+
   newproperty(:readonly) do
     desc 'Puts the database into read-only mode.'
   end

--- a/spec/unit/puppet/type/openldap_database_spec.rb
+++ b/spec/unit/puppet/type/openldap_database_spec.rb
@@ -98,4 +98,16 @@ describe Puppet::Type.type(:openldap_database) do
       expect(@password.should_to_s('newpass')).to match(%r{^\[new password hash redacted\]$})
     end
   end
+
+  describe "organization" do
+    it 'should set organization to foo.bar' do
+      @resource = described_class.new(name: 'foo', suffix: 'dc=foo,dc=bar')
+      expect(@resource[:organization]).to eq('foo.bar')
+    end
+
+    it 'should be nil when suffix is not using dc' do
+      @resource = described_class.new(name: 'foo', suffix: 'ou=foo,dc=bar')
+      expect(@resource[:organization]).to be_nil
+    end
+  end
 end

--- a/spec/unit/puppet/type/openldap_database_spec.rb
+++ b/spec/unit/puppet/type/openldap_database_spec.rb
@@ -99,13 +99,13 @@ describe Puppet::Type.type(:openldap_database) do
     end
   end
 
-  describe "organization" do
-    it 'should set organization to foo.bar' do
+  describe 'organization' do
+    it 'sets organization to foo.bar' do
       @resource = described_class.new(name: 'foo', suffix: 'dc=foo,dc=bar')
       expect(@resource[:organization]).to eq('foo.bar')
     end
 
-    it 'should be nil when suffix is not using dc' do
+    it 'is nil when suffix is not using dc' do
       @resource = described_class.new(name: 'foo', suffix: 'ou=foo,dc=bar')
       expect(@resource[:organization]).to be_nil
     end


### PR DESCRIPTION
Make the "o" attribute configurable via organization parameter
Use rootdn for LDAP Administrator instead of hardcoded cn=admin