### PR TITLE
Delete database dc=my-domain,dc=com on RedHat systems

### DIFF
--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -32,7 +32,7 @@ class openldap::server::slapdconf {
     fail 'You must specify a ssl_cert'
   }
 
-  if $facts['os']['family'] == 'Debian' {
+  if $facts['os']['family'] == 'Debian' or $facts['os']['family'] == 'RedHat' {
     openldap::server::database { 'dc=my-domain,dc=com':
       ensure => absent,
     }

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -17,6 +17,8 @@ describe 'openldap::server::slapdconf' do
         case facts[:osfamily]
         when 'Debian'
           it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
+        when 'RedHat'
+          it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
         else
           it { is_expected.not_to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
         end

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -15,9 +15,7 @@ describe 'openldap::server::slapdconf' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::slapdconf') }
         case facts[:osfamily]
-        when 'Debian'
-          it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
-        when 'RedHat'
+        when %r{Debian|RedHat}
           it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
         else
           it { is_expected.not_to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }

--- a/spec/classes/openldap_server_spec.rb
+++ b/spec/classes/openldap_server_spec.rb
@@ -53,7 +53,8 @@ describe 'openldap::server' do
                                                                       ssl_key: nil,
                                                                       ssl_ca: nil)
               }
-              it { is_expected.to have_openldap__server__database_resource_count(0) }
+              it { is_expected.to have_openldap__server__database_resource_count(1) }
+              it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
             else
               it {
                 is_expected.to contain_class('openldap::server').with(package: 'openldap-servers',
@@ -64,7 +65,8 @@ describe 'openldap::server' do
                                                                       ssl_key: nil,
                                                                       ssl_ca: nil)
               }
-              it { is_expected.to have_openldap__server__database_resource_count(0) }
+              it { is_expected.to have_openldap__server__database_resource_count(1) }
+              it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
             end
           end
         end


### PR DESCRIPTION
This partially reverts this particular change from #187.  Maybe the if condition is unnecessary and should just always delete the domain?