### PR TITLE
Switch to regular OpenLDAP packages on FreeBSD

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -56,13 +56,13 @@ class openldap::params {
       $enable_memory_limit      = undef
     }
     'FreeBSD': {
-      $client_package           = 'openldap-sasl-client'
+      $client_package           = 'openldap-client'
       $client_conffile          = '/usr/local/etc/openldap/ldap.conf'
       $server_confdir           = '/usr/local/etc/openldap/slapd.d'
       $server_conffile          = '/usr/local/etc/openldap/slapd.conf'
       $server_group             = 'ldap'
       $server_owner             = 'ldap'
-      $server_package           = 'openldap-sasl-server'
+      $server_package           = 'openldap-server'
       $server_service           = 'slapd'
       $utils_package            = undef
       $escape_ldapi_ifs         = true


### PR DESCRIPTION
FreeBSD openldap packages used to be compiled without SASL support,
needed for OLC configuration to work, so the module default to these
versions of the package with SASL support.

Recently [1], the ports where updated so that the base package have SASL
support, and non-SASL OpenLDAP is not available anymore on FreeBSD.  As
a consequence, the openldap-sasl-client and openldap-sasl-server do not
exist anymore.

Update the names of the default packages used on FreeBSD to match what
is actually the default.

References:
  1. https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=257374