### PR TITLE
Acceptance tests for CentOS 7 , remove RHEL6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
         run: bundle exec rake rubocop
       - name: Setup Test Matrix
         id: get-outputs
-        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround false
+        run: bundle exec metadata2gha --use-fqdn --pidfile-workaround CentOS
 
   unit:
     needs: setup_matrix

--- a/.sync.yml
+++ b/.sync.yml
@@ -1,3 +1,5 @@
 ---
+.github/workflows/ci.yml:
+  pidfile_workaround: CentOS
 spec/spec_helper_acceptance.rb:
   unmanaged: false

--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,12 @@
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
-        "6",
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
         "7"
       ]
     },

--- a/spec/acceptance/schema_spec.rb
+++ b/spec/acceptance/schema_spec.rb
@@ -61,7 +61,11 @@ describe 'openldap::server::schema' do
   context 'remove custom schema' do
     it 'cleans up custom schema' do
       shell('service slapd stop')
-      shell('rm /etc/ldap/slapd.d/cn=config/cn=schema/*puppet.ldif')
+      if fact('os.family') == 'RedHat'
+        shell('rm /etc/openldap/slapd.d/cn=config/cn=schema/*puppet.ldif')
+      else
+        shell('rm /etc/ldap/slapd.d/cn=config/cn=schema/*puppet.ldif')
+      end
       shell('service slapd start')
     end
   end

--- a/spec/setup_acceptance_node.pp
+++ b/spec/setup_acceptance_node.pp
@@ -1,4 +1,16 @@
-package { 'ssl-cert':
+case $facts['os']['family'] {
+  'Debian': {
+    $package_name = 'ssl-cert'
+    $ssl_key_source = '/etc/ssl/private/ssl-cert-snakeoil.key'
+    $ssl_cert_source = '/etc/ssl/certs/ssl-cert-snakeoil.pem'
+  }
+  'RedHat': {
+    $package_name = 'mod_ssl'
+    $ssl_key_source = '/etc/pki/tls/private/localhost.key'
+    $ssl_cert_source = '/etc/pki/tls/certs/localhost.crt'
+  }
+}
+package { $package_name:
   ensure => installed,
 }
 file { '/etc/ldap':
@@ -10,15 +22,32 @@ file { '/etc/ldap/ssl':
 file { "/etc/ldap/ssl/${::fqdn}.key":
   ensure  => file,
   mode    => '0644',
-  source  => "/etc/ssl/private/ssl-cert-snakeoil.key",
+  source  => $ssl_key_source,
 }
 file { "/etc/ldap/ssl/${::fqdn}.crt":
   ensure  => file,
   mode    => '0644',
-  source  => "/etc/ssl/certs/ssl-cert-snakeoil.pem",
+  source  => $ssl_cert_source,
 }
 file { '/etc/ldap/ssl/ca.pem':
   ensure  => file,
   mode    => '0644',
-  source  => "/etc/ssl/certs/ssl-cert-snakeoil.pem",
+  source  => $ssl_cert_source,
+}
+
+# Hack to work around issues with recent systemd and docker with systemd running services as non-root
+if $facts['os']['family'] == 'RedHat' {
+  file { '/etc/systemd/system/slapd.service.d': ensure => 'directory' }
+  file { '/etc/systemd/system/slapd.service.d/hack.conf':
+    ensure  => 'file',
+    content => join([
+      '[Service]',
+      'User=root',
+      'Group=root',
+      'ExecStartPre=',
+      'ExecStartPre=/usr/bin/chown root:root /var/run/openldap',
+      'ExecStart=',
+      'ExecStart=/usr/sbin/slapd -u root -h ${SLAPD_URLS} $SLAPD_OPTIONS',
+    ], "\n"),
+  }
 }


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->
Add CentOS 7 to metadata.json hoping that will trigger acceptance tests.
Remove RHEL6 from metadata.json, that OS version is EOL

