### PR TITLE
Fix type of $openldap::server::access_wrapper::acl

### DIFF
--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -21,7 +21,7 @@
 #     }
 #
 define openldap::server::access_wrapper (
-  String[1] $acl,
+  Hash[String[1],Array[String[1]]] $acl,
   String[1] $suffix = $name,
 ) {
   # Parse ACL

--- a/spec/defines/openldap_server_access_wrapper_spec.rb
+++ b/spec/defines/openldap_server_access_wrapper_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+
+describe 'openldap::server::access_wrapper' do
+  let(:title) { 'foo' }
+
+  let :pre_condition do
+    "class {'openldap::server':}"
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts
+      end
+
+      let(:params) do
+        {
+          acl: {
+            '1 to *' => [
+              'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+              'by dn.exact=cn=admin,dc=example,dc=com write',
+              'by dn.exact=cn=replicator,dc=example,dc=com read',
+              'by * break',
+            ],
+            'to attrs=userPassword,shadowLastChange' => [
+              'by dn="cn=admin,dc=example,dc=com" write',
+              'by self write',
+              'by anonymous auth',
+            ],
+            '2 to *' => [
+              'by self read',
+            ],
+          }
+        }
+      end
+
+      it { is_expected.to compile.with_all_deps }
+      it { is_expected.to have_openldap__server__access_resource_count(3) }
+    end
+  end
+end


### PR DESCRIPTION
This wrapper defined type did not have tests and we unfortunately
broke it when we added data types.

Add a basic unit test using the example in the README file.
