### PR TITLE
Fix purging puppet resource openldap_access

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -43,7 +43,7 @@ Puppet::Type.
                      false
                    end
           i << new(
-            name: "{#{position}}to #{what} #{access.join(' ')} on #{suffix}",
+            name: "#{position} on #{suffix}",
             ensure: :present,
             position: position,
             what: what,
@@ -108,9 +108,7 @@ Puppet::Type.
   end
 
   def exists?
-    resource[:suffix] == (@property_hash[:suffix]) &&
-      resource[:access].flatten == @property_hash[:access].flatten &&
-      resource[:what] == (@property_hash[:what])
+    @property_hash[:ensure] == :present
   end
 
   def create

--- a/metadata.json
+++ b/metadata.json
@@ -29,15 +29,12 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8",
-        "9",
         "10"
       ]
     },
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04",
         "18.04",
         "20.04"
       ]

--- a/metadata.json
+++ b/metadata.json
@@ -29,7 +29,8 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     },
     {


### PR DESCRIPTION
The provider returned inconsistent entries, some of them having their
`ensure` property set to `absent` and no `access` property.

This fix this issue by using another format for the generated resource
titles (to match what is done by the module when managing resources from
Puppet code) and reworking the way an existing resource is detected.


This PR also include:

* #313 
* #314 