### PR TITLE
Fix data type for $openldap::server::globalconf::value

### DIFF
--- a/manifests/server/globalconf.pp
+++ b/manifests/server/globalconf.pp
@@ -1,6 +1,6 @@
 # See README.md for details.
 define openldap::server::globalconf (
-  Variant[String[1],Hash[String[1], String[1]]] $value,
+  Variant[String[1],Array[String[1]],Hash[String[1], Variant[String[1],Array[String[1]]]]] $value,
   Enum['present', 'absent']                     $ensure = 'present',
 ) {
   if ! defined(Class['openldap::server']) {


### PR DESCRIPTION
openldap_global_conf also support passing arrays of values, so add this
to the corresponding data type.

Fixes #317
