### PR TITLE
Update FreeBSD package names

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,7 +1,7 @@
 ---
-openldap::client::package: "openldap-client"
+openldap::client::package: "openldap24-client"
 openldap::client::file: "/usr/local/etc/openldap/ldap.conf"
 openldap::server::confdir: "/usr/local/etc/openldap/slapd.d"
 openldap::server::conffile: "/usr/local/etc/openldap/slapd.conf"
-openldap::server::package: "openldap-server"
+openldap::server::package: "openldap24-server"
 openldap::server::escape_ldapi_ifs: true


### PR DESCRIPTION
FreeBSD ports for OpenLDAP 2.5 have been committed to FreeBSD a few days
ago and are available as net/openldap25-client / net/openldap25-server.

To avoid package name conflicts, the old packages for OpenLDAP 2.4
provided by net/openldap24-client and net/openldap24-server have been
[renamed]:

  * openldap-client => openldap24-client
  * openldap-server => openldap24-server

We no longuer ship openldap-client / openldap-server packages, so use
the new name for the OpenLDAP 2.4 packages.

[renamed]: https://cgit.freebsd.org/ports/commit/?id=91966715bcf3989bd7c96e5910f0a83952eecdc6
