### PR TITLE
Include missing class instead of raising an error

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -29,9 +29,14 @@ class openldap::server (
   Optional[String] $ldap_config_backend             = undef,
   Optional[Boolean] $enable_memory_limit            = undef,
 ) {
-  class { 'openldap::server::install': }
-  -> class { 'openldap::server::config': }
-  ~> class { 'openldap::server::service': }
-  -> class { 'openldap::server::slapdconf': }
+  include openldap::server::install
+  include openldap::server::config
+  include openldap::server::service
+  include openldap::server::slapdconf
+
+  Class['openldap::server::install']
+  -> Class['openldap::server::config']
+  ~> Class['openldap::server::service']
+  -> Class['openldap::server::slapdconf']
   -> Class['openldap::server']
 }

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -7,9 +7,7 @@ define openldap::server::access (
   Optional[Array[String[1]]]           $access   = undef,
   Boolean                              $islast   = false,
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   Class['openldap::server::service']
   -> Openldap::Server::Access[$title]

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -1,22 +1,21 @@
 # See README.md for details.
-class openldap::server::config (
-  Optional[String[1]]            $slapd_params        = $openldap::server::slapd_params,
-  String[1]                      $owner               = $openldap::server::owner,
-  String[1]                      $group               = $openldap::server::group,
-  Optional[Boolean]              $enable_chown        = $openldap::server::enable_chown,
-  Optional[Integer[1]]           $ldap_port           = $openldap::server::ldap_port,
-  Optional[String[1]]            $ldap_address        = $openldap::server::ldap_address,
-  Optional[Integer[1]]           $ldaps_port          = $openldap::server::ldaps_port,
-  Optional[String[1]]            $ldaps_address       = $openldap::server::ldaps_address,
-  Optional[String[1]]            $ldapi_socket_path   = $openldap::server::ldapi_socket_path,
-  Optional[Boolean]              $register_slp        = $openldap::server::register_slp,
-  Optional[Stdlib::Absolutepath] $krb5_keytab_file    = $openldap::server::krb5_keytab_file,
-  Optional[String[1]]            $ldap_config_backend = $openldap::server::ldap_config_backend,
-  Optional[Boolean]              $enable_memory_limit = $openldap::server::enable_memory_limit,
-) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+class openldap::server::config {
+  include openldap::server
+
+  $slapd_params        = $openldap::server::slapd_params
+  $owner               = $openldap::server::owner
+  $group               = $openldap::server::group
+  $enable_chown        = $openldap::server::enable_chown
+  $ldap_port           = $openldap::server::ldap_port
+  $ldap_address        = $openldap::server::ldap_address
+  $ldaps_port          = $openldap::server::ldaps_port
+  $ldaps_address       = $openldap::server::ldaps_address
+  $ldapi_socket_path   = $openldap::server::ldapi_socket_path
+  $register_slp        = $openldap::server::register_slp
+  $krb5_keytab_file    = $openldap::server::krb5_keytab_file
+  $ldap_config_backend = $openldap::server::ldap_config_backend
+  $enable_memory_limit = $openldap::server::enable_memory_limit
+
   $slapd_ldap_ifs = empty($openldap::server::ldap_ifs) ? {
     false => join(prefix($openldap::server::ldap_ifs, 'ldap://'), ' '),
     true  => '',

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -23,9 +23,7 @@ define openldap::server::database (
   Optional[Variant[String[1],Array[String[1]]]] $syncrepl        = undef,
   Optional[String[1]]                           $security        = undef,
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   $manage_directory = $backend ? {
     'monitor' => undef,

--- a/manifests/server/dbindex.pp
+++ b/manifests/server/dbindex.pp
@@ -5,9 +5,7 @@ define openldap::server::dbindex (
   String[1]                           $attribute = $name,
   Optional[String[1]]                 $indices   = undef,
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   openldap_dbindex { $title:
     ensure    => $ensure,

--- a/manifests/server/globalconf.pp
+++ b/manifests/server/globalconf.pp
@@ -3,9 +3,7 @@ define openldap::server::globalconf (
   Variant[String[1],Array[String[1]],Hash[String[1], Variant[String[1],Array[String[1]]]]] $value,
   Enum['present', 'absent']                     $ensure = 'present',
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   Class['openldap::server::service']
   -> Openldap::Server::Globalconf[$title]

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -1,8 +1,6 @@
 # See README.md for details.
 class openldap::server::install {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   contain openldap::utils
 

--- a/manifests/server/module.pp
+++ b/manifests/server/module.pp
@@ -2,9 +2,7 @@
 define openldap::server::module (
   Optional[Enum['present', 'absent']] $ensure = undef,
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   Class['openldap::server::service']
   -> Openldap::Server::Module[$title]

--- a/manifests/server/overlay.pp
+++ b/manifests/server/overlay.pp
@@ -5,9 +5,7 @@ define openldap::server::overlay (
   String[1]                                                     $suffix  = regsubst($title, '^(\S+)\s+on\s+(\S+)$', '\2'),
   Optional[Variant[Array[String[1]],Hash[String[1],String[1]]]] $options = undef,
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   Class['openldap::server::service']
   -> Openldap::Server::Overlay[$title]

--- a/manifests/server/schema.pp
+++ b/manifests/server/schema.pp
@@ -9,9 +9,7 @@ define openldap::server::schema (
     'Suse' => "/etc/openldap/schema/${title}.schema",
   }
 ) {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   Class['openldap::server::service']
   -> Openldap::Server::Schema[$title]

--- a/manifests/server/service.pp
+++ b/manifests/server/service.pp
@@ -1,8 +1,6 @@
 # See README.md for details.
 class openldap::server::service {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   $ensure = $openldap::server::start ? {
     true    => running,

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -1,8 +1,6 @@
 # See README.md for details.
 class openldap::server::slapdconf {
-  if ! defined(Class['openldap::server']) {
-    fail 'class openldap::server has not been evaluated'
-  }
+  include openldap::server
 
   file { $openldap::server::confdir:
     ensure => directory,

--- a/spec/classes/openldap_server_config_spec.rb
+++ b/spec/classes/openldap_server_config_spec.rb
@@ -8,10 +8,6 @@ describe 'openldap::server::config' do
       end
 
       context 'with no parameters' do
-        let :pre_condition do
-          "class {'openldap::server':}"
-        end
-
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::config') }
         it { is_expected.not_to contain_openldap__globalconf('TLSCertificateFile') }

--- a/spec/classes/openldap_server_install_spec.rb
+++ b/spec/classes/openldap_server_install_spec.rb
@@ -8,10 +8,6 @@ describe 'openldap::server::install' do
       end
 
       context 'with no parameters' do
-        let :pre_condition do
-          "class {'openldap::server':}"
-        end
-
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::install') }
         case facts[:osfamily]

--- a/spec/classes/openldap_server_service_spec.rb
+++ b/spec/classes/openldap_server_service_spec.rb
@@ -9,10 +9,6 @@ describe 'openldap::server::service' do
       end
 
       context 'with no parameters' do
-        let :pre_condition do
-          "class {'openldap::server':}"
-        end
-
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::service') }
         case facts[:osfamily]

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -8,10 +8,6 @@ describe 'openldap::server::slapdconf' do
       end
 
       context 'with no parameters' do
-        let :pre_condition do
-          "class {'openldap::server':}"
-        end
-
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::slapdconf') }
         case facts[:osfamily]

--- a/spec/defines/openldap_server_access_spec.rb
+++ b/spec/defines/openldap_server_access_spec.rb
@@ -3,20 +3,10 @@ require 'spec_helper'
 describe 'openldap::server::access' do
   let(:title) { 'foo' }
 
-  let :pre_condition do
-    "class {'openldap::server':}"
-  end
-
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
         facts
-      end
-
-      context 'when Class[openldap::server] is not declared' do
-        let(:pre_condition) {}
-
-        it { is_expected.to compile.and_raise_error(%r{class openldap::server has not been evaluated}) }
       end
 
       context 'with composite namevar' do

--- a/spec/defines/openldap_server_access_wrapper_spec.rb
+++ b/spec/defines/openldap_server_access_wrapper_spec.rb
@@ -3,10 +3,6 @@ require 'spec_helper'
 describe 'openldap::server::access_wrapper' do
   let(:title) { 'foo' }
 
-  let :pre_condition do
-    "class {'openldap::server':}"
-  end
-
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do

--- a/spec/defines/openldap_server_database_spec.rb
+++ b/spec/defines/openldap_server_database_spec.rb
@@ -9,21 +9,11 @@ describe 'openldap::server::database' do
         facts
       end
 
-      context 'without declaring Class[openldap::server]' do
-        let(:params) { { directory: '/foo/bar' } }
-
-        it { is_expected.to compile.and_raise_error(%r{class openldap::server has not been evaluated}) }
-      end
-
       context 'with a valid directory' do
         let(:params) { { directory: '/foo/bar' } }
 
         context 'with olc provider' do
           context 'with no parameters' do
-            let :pre_condition do
-              "class { 'openldap::server': }"
-            end
-
             it { is_expected.to compile.with_all_deps }
             it {
               is_expected.to contain_openldap__server__database('foo').with(directory: '/foo/bar')

--- a/spec/defines/openldap_server_globalconf_spec.rb
+++ b/spec/defines/openldap_server_globalconf_spec.rb
@@ -16,18 +16,10 @@ describe 'openldap::server::globalconf' do
       context 'with a value' do
         let(:params) { { value: 'bar' } }
 
-        context 'with olc provider' do
-          context 'with no parameters' do
-            let :pre_condition do
-              "class { 'openldap::server': }"
-            end
-
-            it { is_expected.to compile.with_all_deps }
-            it {
-              is_expected.to contain_openldap__server__globalconf('foo').with(value: 'bar')
-            }
-          end
-        end
+        it { is_expected.to compile.with_all_deps }
+        it {
+          is_expected.to contain_openldap_global_conf('foo').with(value: 'bar')
+        }
       end
     end
   end

--- a/spec/defines/openldap_server_module_spec.rb
+++ b/spec/defines/openldap_server_module_spec.rb
@@ -9,15 +9,7 @@ describe 'openldap::server::module' do
         facts
       end
 
-      context 'without declaring Class[openldap::server]' do
-        it { is_expected.to compile.and_raise_error(%r{openldap::server has not been evaluated}) }
-      end
-
       context 'without parameter' do
-        let :pre_condition do
-          "class { 'openldap::server': }"
-        end
-
         it { is_expected.to compile.with_all_deps }
       end
     end

--- a/spec/defines/openldap_server_overlay_spec.rb
+++ b/spec/defines/openldap_server_overlay_spec.rb
@@ -3,20 +3,10 @@ require 'spec_helper'
 describe 'openldap::server::overlay' do
   let(:title) { 'memberof on dc=example,dc=com' }
 
-  let :pre_condition do
-    "class {'openldap::server':}"
-  end
-
   on_supported_os.each do |os, facts|
     context "on #{os}" do
       let(:facts) do
         facts
-      end
-
-      context 'when Class[openldap::server] is not declared' do
-        let(:pre_condition) {}
-
-        it { is_expected.to compile.and_raise_error(%r{class openldap::server has not been evaluated}) }
       end
 
       context 'with ensure => present' do

--- a/spec/defines/openldap_server_schema_spec.rb
+++ b/spec/defines/openldap_server_schema_spec.rb
@@ -9,15 +9,7 @@ describe 'openldap::server::schema' do
         facts
       end
 
-      context 'without declaring Class[openldap::server]' do
-        it { is_expected.to compile.and_raise_error(%r{openldap::server has not been evaluated}) }
-      end
-
       context 'without parameter' do
-        let :pre_condition do
-          "class { 'openldap::server': }"
-        end
-
         it { is_expected.to compile.with_all_deps }
       end
     end


### PR DESCRIPTION
This make our life easier when testing because we generally do not want
to tweak any configuration.
