### PR TITLE
Be more strict with access resource titles / ACL syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,26 +150,7 @@ openldap::server::overlay { 'memberof on dc=example,dc=com':
 [Documentation](http://www.openldap.org/devel/admin/slapdconf2.html) about olcAcces state the following spec:
 > 5.2.5.2. olcAccess: to &lt;what&gt; \[ by &lt;who&gt; \[&lt;accesslevel&gt;\] \[&lt;control&gt;\] \]+
 
-So we supports natively this way of writing in the title:
-```puppet
-openldap::server::access { 'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth' :
-  suffix   => 'dc=example,dc=com',
-}
-```
-
-Also is supported writing priority in title like olcAccess in ldap
-```puppet
-openldap::server::access { '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth' :
-  suffix   => 'dc=example,dc=com',
-}
-```
-
-As a single line with suffix:
-```puppet
-openldap::server::access { '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com' : }
-```
-
-Defining priority and suffix in the title:
+Define priority and suffix in the title:
 ```puppet
 openldap::server::access { '0 on dc=example,dc=com':
   what     => 'attrs=userPassword,shadowLastChange',
@@ -200,34 +181,14 @@ openldap::server::access { '0 on cn=frontend' :
 }
 ```
 
-
-#### Note #1:
-The chaining arrows `->` are importants if you want to order your entries.
-Openldap put the entry as the last available position.
-So if you got in your ldap:
-```
- olcAccess: {0}to ...
- olcAccess: {1}to ...
- olcAccess: {2}to ...
-```
-
-  Even if you set the parameter `position => '4'`, the next entry will be set as
-
-```
- olcAccess: {3}to ...
-```
-
-#### Note #2:
+#### Note:
 For purging unmanaged entries, rely on the `resources` resource:
 
 ```
 resources { 'openldap_access':
   purge => true,
 }
-```
 
-It is then necessary to identify access rules using the *priority and suffix* syntax for the title:
-```puppet
 openldap::server::access { '0 on dc=example,dc=com':
   what   => ...,
   access => [...],
@@ -238,11 +199,9 @@ openldap::server::access { '1 on dc=example,dc=com':
 }
 ```
 
-entries 2 and 3 will get deleted.
-
 #### Call your acl from a hash:
 The class `openldap::server::access_wrapper` was designed to simplify creating ACL.
-If you have multiple `what` (`to *` in this example), you can order them by adding number to it.
+In order to avoid collisions when multiple identical `what` are present (`to *` in this example), a (meaningless) number must be prepended to each entry.
 
 ```puppet
 $example_acl = {
@@ -252,12 +211,12 @@ $example_acl = {
     'by dn.exact=cn=replicator,dc=example,dc=com read',
     'by * break',
   ],
-  'to attrs=userPassword,shadowLastChange' => [
+  '2 to attrs=userPassword,shadowLastChange' => [
     'by dn="cn=admin,dc=example,dc=com" write',
     'by self write',
     'by anonymous auth',
   ],
-  '2 to *' => [
+  '3 to *' => [
     'by self read',
   ],
 }

--- a/README.md
+++ b/README.md
@@ -201,25 +201,32 @@ openldap::server::access { '1 on dc=example,dc=com':
 
 #### Call your acl from a hash:
 The class `openldap::server::access_wrapper` was designed to simplify creating ACL.
-In order to avoid collisions when multiple identical `what` are present (`to *` in this example), a (meaningless) number must be prepended to each entry.
+Each ACL is distinct hash in order to avoid collisions when multiple identical `what` are present (`to *` in this example).
 
 ```puppet
-$example_acl = {
-  '1 to *' => [
-    'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
-    'by dn.exact=cn=admin,dc=example,dc=com write',
-    'by dn.exact=cn=replicator,dc=example,dc=com read',
-    'by * break',
-  ],
-  '2 to attrs=userPassword,shadowLastChange' => [
-    'by dn="cn=admin,dc=example,dc=com" write',
-    'by self write',
-    'by anonymous auth',
-  ],
-  '3 to *' => [
-    'by self read',
-  ],
-}
+$example_acl = [
+  {
+    'to *' => [
+      'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+      'by dn.exact=cn=admin,dc=example,dc=com write',
+      'by dn.exact=cn=replicator,dc=example,dc=com read',
+      'by * break',
+    ],
+  },
+  {
+    'to attrs=userPassword,shadowLastChange' => [
+      'by dn="cn=admin,dc=example,dc=com" write',
+      'by self write',
+      'by anonymous auth',
+    ],
+  },
+  {
+    'to *' => [
+      'by self read',
+    ],
+  },
+]
+
 
 openldap::server::access_wrapper { 'dc=example,dc=com' :
   acl => $example_acl,

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -44,56 +44,13 @@ Puppet::Type.newtype(:openldap_access) do
   end
 
   def self.title_patterns
-    what_re = %r{\S+=\S+(?:\s+\S+=\S+)*}
     [
-      [
-        %r{^(\{(\d+)\}to\s+(#{what_re})\s+(by\s+.+)\s+on\s+(.+))$},
-        [
-          [:name],
-          [:position],
-          [:what],
-          [:access],
-          [:suffix],
-        ],
-      ],
-      [
-        %r{^(\{(\d+)\}to\s+(#{what_re})\s+(by\s+.+))$},
-        [
-          [:name],
-          [:position],
-          [:what],
-          [:access],
-        ],
-      ],
-      [
-        %r{^(to\s+(#{what_re})\s+(by\s+.+)\s+on\s+(.+))$},
-        [
-          [:name],
-          [:what],
-          [:access],
-          [:suffix],
-        ],
-      ],
-      [
-        %r{^(to\s+(#{what_re})\s+(by\s+.+))$},
-        [
-          [:name],
-          [:what],
-          [:access],
-        ],
-      ],
       [
         %r{^((\d+)\s+on\s+(.+))$},
         [
           [:name],
           [:position],
           [:suffix],
-        ],
-      ],
-      [
-        %r{(.*)},
-        [
-          [:name],
         ],
       ],
     ]

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -1,10 +1,8 @@
 # See README.md for details.
 define openldap::server::access (
-  Optional[Enum['present', 'absent']]  $ensure   = undef,
-  Optional[Variant[Integer,String[1]]] $position = undef, # FIXME We should probably choose Integer or String
-  Optional[String[1]]                  $what     = undef,
-  Optional[String[1]]                  $suffix   = undef,
-  Optional[Array[String[1]]]           $access   = undef,
+  String[1]                            $what,
+  Array[Openldap::Access_rule]         $access,
+  Enum['present', 'absent']            $ensure   = 'present',
 ) {
   include openldap::server
 
@@ -13,11 +11,9 @@ define openldap::server::access (
   -> Class['openldap::server']
 
   openldap_access { $title:
-    ensure   => $ensure,
-    position => $position,
-    target   => $openldap::server::conffile,
-    what     => $what,
-    suffix   => $suffix,
-    access   => $access,
+    ensure => $ensure,
+    target => $openldap::server::conffile,
+    what   => $what,
+    access => $access,
   }
 }

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -14,14 +14,14 @@
 #
 #   example:
 #     $acl = {
-#       'to *' => [
+#       '1 to *' => [
 #         'by self write',
 #         'by anonymous read',
 #       ],
 #     }
 #
 define openldap::server::access_wrapper (
-  Hash[String[1],Array[String[1]]] $acl,
+  Hash[Pattern[/\A\d+ to\s/],Array[Openldap::Access_rule]] $acl,
   String[1] $suffix = $name,
 ) {
   # Parse ACL

--- a/manifests/server/access_wrapper.pp
+++ b/manifests/server/access_wrapper.pp
@@ -10,35 +10,64 @@
 #
 # [*acl*]
 #   Default:
-#   Mandatory. Hash in the form { <what> => <access>, ... }
+#   Mandatory. Array of Hash in the form { <what> => <access>, ... }
 #
 #   example:
-#     $acl = {
-#       '1 to *' => [
-#         'by self write',
-#         'by anonymous read',
-#       ],
-#     }
+#     $acl = [
+#       {
+#         'to *'                       => [
+#           'by dn.base="cn=replicator,dc=suretecsystems,dc=com" write',
+#           'by * break'
+#         ],
+#       },
+#       {
+#         'to dn.base=""'              => [
+#           'by * read',
+#         ],
+#       },
+#       {
+#         'to dn.base="cn=Subschema"'  => [
+#           'by * read',
+#         ],
+#       },
+#       {
+#         'to dn.subtree="cn=Monitor"' => [
+#           'by dn.exact="uid=admin,dc=suretecsystems,dc=com" write',
+#           'by users read',
+#           'by * none',
+#         ],
+#       },
+#       {
+#         'to *'                       => [
+#           'by self write',
+#           'by * none',
+#         ]
+#       },
+#     ]
 #
 define openldap::server::access_wrapper (
-  Hash[Pattern[/\A\d+ to\s/],Array[Openldap::Access_rule]] $acl,
+  Array[Hash[Pattern[/\Ato\s/], Array[Openldap::Access_rule], 1, 1]] $acl,
   String[1] $suffix = $name,
 ) {
   # Parse ACL
-$acl_yaml = inline_template('<%=
-    position = -1
-    @acl.map { |to,access|
-      position = position + 1
-      {
-        "#{position} on #{@suffix}" => {
-          "position" => position,
-          "what"     => to[/.*\bto (.*)/,1],
-          "access"   => access,
-          "suffix"   => "#{@suffix}",
-        }
-      }
-  }.flatten.reduce({}, :update).to_yaml
-  %>')
+  $acl_yaml = inline_template(@("RUBY"))
+    <%=
+      position = -1
+      @acl.map do |acl|
+        acl.map do |to, access|
+          position = position + 1
+          {
+            "#{position} on #{@suffix}" => {
+              "position" => position,
+              "what"     => to[/\Ato (.*)/, 1],
+              "access"   => access,
+              "suffix"   => "#{@suffix}",
+            }
+          }
+        end
+      end.flatten.reduce({}, :update).to_yaml
+    %>
+    | RUBY
 
   $hash = parseyaml($acl_yaml)
   $hash_keys = keys($hash)

--- a/manifests/server/iterate_access.pp
+++ b/manifests/server/iterate_access.pp
@@ -1,6 +1,6 @@
 #  This is a 'private' class used by openldap::server::access_wrapper
 define openldap::server::iterate_access (
-  Hash $hash,
+  Openldap::Access_hash $hash,
 ) {
   # Call individual openldap::server::access
   $position = $hash[$name]['position']

--- a/spec/acceptance/openldap__server__access_spec.rb
+++ b/spec/acceptance/openldap__server__access_spec.rb
@@ -26,20 +26,17 @@ describe 'openldap::server::access' do
       pp = <<-EOS
         class { 'openldap::server': }
         openldap::server::database { 'dc=example,dc=com' : }
-        openldap::server::access { 'admin':
+        openldap::server::access { '0 on dc=example,dc=com':
           what    => 'attrs=userPassword,distinguishedName',
           access  => ['by dn="cn=admin,dc=example,dc=com" write'],
-          suffix  => 'dc=example,dc=com',
           require => Openldap::Server::Database['dc=example,dc=com'],
         }
-        openldap::server::access { 'root':
+        openldap::server::access { '1 on dc=example,dc=com':
           what    => '*',
           access  => [
             'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
             'by * break'
           ],
-          suffix  => 'dc=example,dc=com',
-          position => 0,
           require => Openldap::Server::Database['dc=example,dc=com'],
         }
       EOS

--- a/spec/defines/openldap_server_access_spec.rb
+++ b/spec/defines/openldap_server_access_spec.rb
@@ -12,7 +12,7 @@ describe 'openldap::server::access' do
       context 'with valid parameters' do
         let(:params) do
           {
-            what: 'to *',
+            what: '*',
             access: [
               'by * read',
             ],
@@ -34,7 +34,7 @@ describe 'openldap::server::access' do
       context 'with access as an array' do
         let(:params) do
           {
-            what: 'to attrs=userPassword,shadowLastChange',
+            what: 'attrs=userPassword,shadowLastChange',
             access: [
               'by dn="cn=admin,dc=example,dc=com" write',
               'by anonymous read',
@@ -45,7 +45,7 @@ describe 'openldap::server::access' do
         it { is_expected.to compile.with_all_deps }
         it {
           is_expected.to contain_openldap_access('0 on dc=example,dc=com').
-            with_what('to attrs=userPassword,shadowLastChange').
+            with_what('attrs=userPassword,shadowLastChange').
             with_access(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous read'])
         }
       end

--- a/spec/defines/openldap_server_access_spec.rb
+++ b/spec/defines/openldap_server_access_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'openldap::server::access' do
-  let(:title) { 'foo' }
+  let(:title) { '0 on dc=example,dc=com' }
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
@@ -9,67 +9,32 @@ describe 'openldap::server::access' do
         facts
       end
 
-      context 'with composite namevar' do
-        let(:title) do
-          'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+      context 'with valid parameters' do
+        let(:params) do
+          {
+            what: 'to *',
+            access: [
+              'by * read',
+            ],
+          }
         end
 
         it { is_expected.to compile.with_all_deps }
-        it {
-          is_expected.to contain_openldap_access('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
-        }
-      end
+        it { is_expected.to contain_openldap_access('0 on dc=example,dc=com') }
 
-      context 'with composite namevar, what includes dn and filter' do
-        let(:title) do
-          'to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+        context 'with malformed namevar' do
+          let(:title) do
+            'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
+          end
+
+          it { is_expected.not_to compile.with_all_deps }
         end
-
-        it { is_expected.to compile.with_all_deps }
-        it {
-          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
-        }
-      end
-
-      context 'with composite namevar, what includes dn and attrs' do
-        let(:title) do
-          'to dn.one="ou=users,dc=example,dc=com" attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
-        end
-
-        it { is_expected.to compile.with_all_deps }
-        it {
-          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
-        }
-      end
-
-      context 'with composite namevar, what includes dn, filter and attrs' do
-        let(:title) do
-          'to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
-        end
-
-        it { is_expected.to compile.with_all_deps }
-        it {
-          is_expected.to contain_openldap_access('to dn.one="ou=users,dc=example,dc=com" filter=(objectClass=person) attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
-        }
-      end
-
-      context 'with composite namevar with position' do
-        let(:title) do
-          '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com'
-        end
-
-        it { is_expected.to compile.with_all_deps }
-        it {
-          is_expected.to contain_openldap_access('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" on dc=example,dc=com')
-        }
       end
 
       context 'with access as an array' do
         let(:params) do
           {
-            position: '0',
             what: 'to attrs=userPassword,shadowLastChange',
-            suffix: 'dc=example,dc=com',
             access: [
               'by dn="cn=admin,dc=example,dc=com" write',
               'by anonymous read',
@@ -79,10 +44,8 @@ describe 'openldap::server::access' do
 
         it { is_expected.to compile.with_all_deps }
         it {
-          is_expected.to contain_openldap_access('foo').
-            with_position('0').
+          is_expected.to contain_openldap_access('0 on dc=example,dc=com').
             with_what('to attrs=userPassword,shadowLastChange').
-            with_suffix('dc=example,dc=com').
             with_access(['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous read'])
         }
       end

--- a/spec/defines/openldap_server_access_wrapper_spec.rb
+++ b/spec/defines/openldap_server_access_wrapper_spec.rb
@@ -12,13 +12,13 @@ describe 'openldap::server::access_wrapper' do
       let(:params) do
         {
           acl: {
-            '1 to *' => [
+            '0 to *' => [
               'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
               'by dn.exact=cn=admin,dc=example,dc=com write',
               'by dn.exact=cn=replicator,dc=example,dc=com read',
               'by * break',
             ],
-            'to attrs=userPassword,shadowLastChange' => [
+            '1 to attrs=userPassword,shadowLastChange' => [
               'by dn="cn=admin,dc=example,dc=com" write',
               'by self write',
               'by anonymous auth',

--- a/spec/defines/openldap_server_access_wrapper_spec.rb
+++ b/spec/defines/openldap_server_access_wrapper_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'openldap::server::access_wrapper' do
-  let(:title) { 'foo' }
+  let(:title) { 'dc=example,dc=com' }
 
   on_supported_os.each do |os, facts|
     context "on #{os}" do
@@ -38,6 +38,41 @@ describe 'openldap::server::access_wrapper' do
 
       it { is_expected.to compile.with_all_deps }
       it { is_expected.to have_openldap__server__access_resource_count(3) }
+      it do
+        is_expected.to contain_openldap_access('0 on dc=example,dc=com').with(
+          position: 0,
+          what: '*',
+          access: [
+            'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+            'by dn.exact=cn=admin,dc=example,dc=com write',
+            'by dn.exact=cn=replicator,dc=example,dc=com read',
+            'by * break',
+          ],
+          suffix: 'dc=example,dc=com'
+        )
+      end
+      it do
+        is_expected.to contain_openldap_access('1 on dc=example,dc=com').with(
+          position: 1,
+          what: 'attrs=userPassword,shadowLastChange',
+          access: [
+            'by dn="cn=admin,dc=example,dc=com" write',
+            'by self write',
+            'by anonymous auth',
+          ],
+          suffix: 'dc=example,dc=com'
+        )
+      end
+      it do
+        is_expected.to contain_openldap_access('2 on dc=example,dc=com').with(
+          position: 2,
+          what: '*',
+          access: [
+            'by self read',
+          ],
+          suffix: 'dc=example,dc=com'
+        )
+      end
     end
   end
 end

--- a/spec/defines/openldap_server_access_wrapper_spec.rb
+++ b/spec/defines/openldap_server_access_wrapper_spec.rb
@@ -11,22 +11,28 @@ describe 'openldap::server::access_wrapper' do
 
       let(:params) do
         {
-          acl: {
-            '0 to *' => [
-              'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
-              'by dn.exact=cn=admin,dc=example,dc=com write',
-              'by dn.exact=cn=replicator,dc=example,dc=com read',
-              'by * break',
-            ],
-            '1 to attrs=userPassword,shadowLastChange' => [
-              'by dn="cn=admin,dc=example,dc=com" write',
-              'by self write',
-              'by anonymous auth',
-            ],
-            '2 to *' => [
-              'by self read',
-            ],
-          }
+          acl: [
+            {
+              'to *' => [
+                'by dn.exact=gidNumber=0+uidNumber=0,cn=peercred,cn=external,cn=auth manage',
+                'by dn.exact=cn=admin,dc=example,dc=com write',
+                'by dn.exact=cn=replicator,dc=example,dc=com read',
+                'by * break',
+              ],
+            },
+            {
+              'to attrs=userPassword,shadowLastChange' => [
+                'by dn="cn=admin,dc=example,dc=com" write',
+                'by self write',
+                'by anonymous auth',
+              ],
+            },
+            {
+              'to *' => [
+                'by self read',
+              ],
+            },
+          ],
         }
       end
 

--- a/spec/type_aliases/access_hash_spec.rb
+++ b/spec/type_aliases/access_hash_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Openldap::Access_hash' do
+  context 'valid types' do
+    [
+      {
+        '0 on dc=example,dc=com' => {
+          'what'   => 'attrs=userPassword,shadowLastChange',
+          'access' => [
+            'by dn="cn=admin,dc=example,dc=com" write',
+            'by anonymous auth',
+            'by self write',
+            'by * none',
+          ],
+        },
+      },
+      {
+        '0 on dc=example,dc=com' => {
+          'position' => 3,
+          'suffix'   => 'dc=example,dc=com',
+          'what'     => 'attrs=userPassword,shadowLastChange',
+          'access'   => [
+            'by dn="cn=admin,dc=example,dc=com" write',
+            'by anonymous auth',
+            'by self write',
+            'by * none',
+          ],
+        },
+      },
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/access_rule_spec.rb
+++ b/spec/type_aliases/access_rule_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Openldap::Access_rule' do
+  context 'valid value' do
+    [
+      'by dn="cn=admin,dc=example,dc=com write',
+      'by anonymous auth',
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+end

--- a/spec/type_aliases/access_title_spec.rb
+++ b/spec/type_aliases/access_title_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'Openldap::Access_title' do
+  context 'valid value' do
+    [
+      '0 on dc=example,dc=com',
+    ].each do |value|
+      describe value.inspect do
+        it { is_expected.to allow_value(value) }
+      end
+    end
+  end
+end

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -1,47 +1,14 @@
 require 'spec_helper'
 
 describe Puppet::Type.type(:openldap_access) do
-  describe 'namevar title patterns' do
-    it 'handles componsite name' do
-      access = described_class.new(name: 'to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:name]).to eq('to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
-      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
-    end
-
-    it 'handles componsite name with position' do
-      access = described_class.new(name: '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:position]).to eq('0')
-      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
-      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
-    end
-
-    it 'handles componsite name with position' do
-      access = described_class.new(name: '{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
-      expect(access[:name]).to eq('{0}to attrs=userPassword,shadowLastChange by dn="cn=admin,dc=example,dc=com" write by anonymous auth on dc=example,dc=com')
-      expect(access[:position]).to eq('0')
-      expect(access[:what]).to eq('attrs=userPassword,shadowLastChange')
-      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
-      expect(access[:suffix]).to eq('dc=example,dc=com')
-    end
-
-    it 'handles specific value of attr' do
-      access = described_class.new(name: 'to attrs=objectClass val=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:name]).to eq('to attrs=objectClass val=posixAccount by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
-      expect(access[:what]).to eq('attrs=objectClass val=posixAccount')
-      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
-    end
-  end
-
   describe 'access' do
     it 'handles array of values' do
-      access = described_class.new(name: 'foo', access: ['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
+      access = described_class.new(name: '0 on dc=example,dc=com', access: ['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth'])
       expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write'], ['by anonymous auth']])
     end
 
     it 'handles string' do
-      access = described_class.new(name: 'foo', access: 'by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      access = described_class.new(name: '0 on dc=example,dc=com', access: 'by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
       expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
     end
   end

--- a/types/access_hash.pp
+++ b/types/access_hash.pp
@@ -1,0 +1,10 @@
+# @summary A valid acl value for openldap::server::access_wrapper
+type Openldap::Access_hash = Hash[
+  Openldap::Access_title,
+  Struct[{
+    position => Optional[Variant[Integer,String[1]]],
+    what     => Optional[String[1]],
+    access   => Array[Openldap::Access_rule],
+    suffix   => Optional[String[1]],
+  }],
+]

--- a/types/access_rule.pp
+++ b/types/access_rule.pp
@@ -1,0 +1,2 @@
+# @summary A valid access rule for openldap::server::access
+type Openldap::Access_rule = Pattern[/\Aby /]

--- a/types/access_title.pp
+++ b/types/access_title.pp
@@ -1,0 +1,2 @@
+# @summary A valid title for an openldap::server::access resource
+type Openldap::Access_title = Pattern[/\A\d+ on /]


### PR DESCRIPTION
The openldap_access resource allows a lot of variations in the title for
declaring a resource, making it possible to skip passing parameters such
as `what` and `suffix`.  This flexibility however can confuse Puppet
when it is prefetching resources, leading to catalog compilation
failures.

Impose a more strict format for resource titles, and validate it with
tighter custom types to raise a hopefully meaningful error instead of a
Ruby error because something borked bad.

Fixes #294 