### PR TITLE
Fix openldap_access's what parameter

### DIFF
--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:openldap_access) do
     desc 'Is this olcAccess the last one?'
   end
 
-  newparam(:what) do
+  newproperty(:what) do
     desc 'The entries and/or attributes to which the access applies'
   end
 


### PR DESCRIPTION
This parameter is in fact a property: it reflects something measurable
on the target system and that can be changed.

With this change, `puppet resource openldap_access` will display what
each entry applies to.
