### PR TITLE
Drop support for openldap_access' islast parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ openldap::server::overlay { 'memberof on dc=example,dc=com':
 ### Configuring ACPs/ACLs
 
 [Documentation](http://www.openldap.org/devel/admin/slapdconf2.html) about olcAcces state the following spec:
-> 5.2.5.2. olcAccess: to &lt;what&gt; [ by &lt;who&gt; [&lt;accesslevel&gt;] [&lt;control&gt;] ]+
+> 5.2.5.2. olcAccess: to &lt;what&gt; \[ by &lt;who&gt; \[&lt;accesslevel&gt;\] \[&lt;control&gt;\] \]+
 
 So we supports natively this way of writing in the title:
 ```puppet
@@ -218,20 +218,23 @@ So if you got in your ldap:
 ```
 
 #### Note #2:
-  The parameter `islast` is used for purging remaining entries. Only one `islast` is allowed per suffix. If you got in your ldap:
+For purging unmanaged entries, rely on the `resources` resource:
+
 ```
- olcAccess: {0}to ...
- olcAccess: {1}to ...
- olcAccess: {2}to ...
- olcAccess: {3}to ...
+resources { 'openldap_access':
+  purge => true,
+}
 ```
 
-And set :
+It is then necessary to identify access rules using the *priority and suffix* syntax for the title:
 ```puppet
+openldap::server::access { '0 on dc=example,dc=com':
+  what   => ...,
+  access => [...],
+}
 openldap::server::access { '1 on dc=example,dc=com':
   what   => ...,
   access => [...],
-  islast => true,
 }
 ```
 

--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -43,7 +43,7 @@ Puppet::Type.
             position: position,
             what: what,
             access: access,
-            suffix: suffix,
+            suffix: suffix
           )
         end
       end
@@ -55,7 +55,7 @@ Puppet::Type.
   def self.prefetch(resources)
     accesses = instances
     resources.keys.each do |name|
-      if provider = accesses.find do |access|
+      next unless provider = accesses.find do |access|
         if resources[name][:position]
           access.suffix == resources[name][:suffix] &&
           access.position == resources[name][:position].to_s
@@ -65,8 +65,8 @@ Puppet::Type.
           access.what == resources[name][:what]
         end
       end
-        resources[name].provider = provider
-      end
+
+      resources[name].provider = provider
     end
   end
 
@@ -187,7 +187,7 @@ Puppet::Type.
           t << "olcAccess: {#{olcAccess[:position]}}#{olcAccess[:content]}\n"
         end
       end
-      countOfElement = self.class.getCountOfOlcAccess(resource[:suffix])
+      self.class.getCountOfOlcAccess(resource[:suffix])
       t.close
       Puppet.debug(IO.read(t.path))
       begin

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -15,10 +15,6 @@ Puppet::Type.newtype(:openldap_access) do
     desc 'Where to place the new entry'
   end
 
-  newparam(:islast) do
-    desc 'Is this olcAccess the last one?'
-  end
-
   newproperty(:what) do
     desc 'The entries and/or attributes to which the access applies'
   end

--- a/lib/puppet/type/openldap_access.rb
+++ b/lib/puppet/type/openldap_access.rb
@@ -19,7 +19,7 @@ Puppet::Type.newtype(:openldap_access) do
     desc 'Is this olcAccess the last one?'
   end
 
-  newparam(:what) do
+  newproperty(:what) do
     desc 'The entries and/or attributes to which the access applies'
   end
 

--- a/manifests/server/access.pp
+++ b/manifests/server/access.pp
@@ -5,7 +5,6 @@ define openldap::server::access (
   Optional[String[1]]                  $what     = undef,
   Optional[String[1]]                  $suffix   = undef,
   Optional[Array[String[1]]]           $access   = undef,
-  Boolean                              $islast   = false,
 ) {
   include openldap::server
 
@@ -20,6 +19,5 @@ define openldap::server::access (
     what     => $what,
     suffix   => $suffix,
     access   => $access,
-    islast   => $islast,
   }
 }

--- a/manifests/server/iterate_access.pp
+++ b/manifests/server/iterate_access.pp
@@ -26,7 +26,6 @@ define openldap::server::iterate_access (
     openldap::server::access { "${position} on ${suffix}" :
       what    => $what,
       access  => $access,
-      islast  => true,
       require => Openldap::Server::Access["${previous_position} on ${suffix}"],
     }
   } else {


### PR DESCRIPTION
This parameter allowed puppet to automatically remove unmanaged resources
which where "siblings" of other resource it managed.

Prefer users to explicitly request unmanaged resources to be purged
rather than partially purging some unmanaged resources.

This PR also include:

* #326 (allows me to test this more easily)