### PR TITLE
$dboptions type: Hash instead of String[1]

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -15,7 +15,7 @@ define openldap::server::database (
   Optional[String[1]]                           $updateref       = undef,
   Optional[String[1]]                           $limits          = undef,
   # BDB/HDB options
-  Optional[String[1]]                           $dboptions       = undef,
+  Optional[Hash]                                $dboptions       = undef,
   Optional[String[1]]                           $synctype        = undef,
   # Synchronization options
   Optional[Boolean]                             $mirrormode      = undef,


### PR DESCRIPTION
$dboptions is passed to the openldap_database custom type, and there it's a hash, so the type of $dboptions in this define should also be a Hash.
See the comment in https://github.com/voxpupuli/puppet-openldap/blob/9ecdd0392d680a78ecc1b147413d64e35b8de695/lib/puppet/type/openldap_database.rb#L185

With 'String[1]' as type you'll run into errors like
```
Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Resource Statement, Openldap::Server::Database[<domain>]: parameter 'dboptions' expects a value of type Undef or String, got Struct
```
and I can't find a way around it, except changing the type of $dboptions in this define.

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
