### PR TITLE
suffix chaining to support ldap backend

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -101,6 +101,7 @@ Puppet::Type.
       end
       suffix = "cn=#{backend}" if backend.match(%r{monitor}i) && !suffix
       suffix = "cn=#{backend}" if backend.match(%r{config}i) && !suffix
+      suffix = "cn=#{backend}" if backend.match(%r{ldap}i) && !suffix
       new(
         ensure: :present,
         name: suffix,

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -3,7 +3,6 @@
 require 'puppet/property/boolean'
 
 # rubocop:disable Style/RegexpLiteral
-# rubocop:disable Naming/PredicateName
 Puppet::Type.newtype(:openldap_database) do
   @doc = 'Manages OpenLDAP BDB and HDB databases.'
 
@@ -236,4 +235,3 @@ Puppet::Type.newtype(:openldap_database) do
   end
 end
 # rubocop:enable Style/RegexpLiteral
-# rubocop:enable Naming/PredicateName


### PR DESCRIPTION
#### Pull Request (PR) description

When enabling chaining on a replica a frontend is created with a ldap backend.  The change proposed adds a match on `ldap` so that this database can be configured and managed rather than cause an error.

```
Error: Could not prefetch openldap_database provider 'olc': No resource and no name in property hash in olc instance
```

#### This Pull Request (PR) fixes the following issues

n/a
