### PR TITLE
Update FreeBSD default version for OpenLDAP

### DIFF
--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -1,9 +1,9 @@
 ---
-openldap::client::package: "openldap24-client"
+openldap::client::package: "openldap26-client"
 openldap::client::file: "/usr/local/etc/openldap/ldap.conf"
 openldap::server::confdir: "/usr/local/etc/openldap/slapd.d"
 openldap::server::conffile: "/usr/local/etc/openldap/slapd.conf"
-openldap::server::package: "openldap24-server"
+openldap::server::package: "openldap26-server"
 openldap::server::escape_ldapi_ifs: true
 openldap::server::ldapi_ifs:
   - "/var/run/openldap/ldapi"


### PR DESCRIPTION
FreeBSD ports are now build against OpenLDAP 2.6 by default.  Update the
package names accordingly.

https://cgit.freebsd.org/ports/commit/?id=eebc8b21260631e2b3ec7f21b92d9d0879661d0e