### PR TITLE
Allow spaces in targets of olcAccess statements

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -30,7 +30,7 @@ Puppet::Type.
           suffix = line.split[1]
         when %r{^olcAccess: }
           begin
-            position, what, bys = line.match(%r{^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val=\S+)?)(\s+by\s+.*)+$}).captures
+            position, what, bys = line.match(%r{^olcAccess:\s+\{(\d+)\}to\s+((?:\S*"[^"]+"|\S+)?(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val=\S+)?)(\s+by\s+.*)+$}).captures
           rescue StandardError
             raise Puppet::Error, "Failed to parse olcAccess for suffix '#{suffix}': #{line}"
           end

--- a/spec/unit/puppet/type/openldap_acess_spec.rb
+++ b/spec/unit/puppet/type/openldap_acess_spec.rb
@@ -13,5 +13,15 @@ describe Puppet::Type.type(:openldap_access) do
       access = described_class.new(name: '0 on dc=example,dc=com', access: 'by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
       expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
     end
+
+    it 'handles target with spaces with prefix' do
+      access = described_class.new(name: '0 on dn.subtree="cn=Some String,dc=example,dc=com"', access: 'by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
+    end
+
+    it 'handles target with spaces without prefix' do
+      access = described_class.new(name: '0 on "cn=Some String,dc=example,dc=com"', access: 'by dn="cn=admin,dc=example,dc=com" write by anonymous auth')
+      expect(access[:access]).to eq([['by dn="cn=admin,dc=example,dc=com" write', 'by anonymous auth']])
+    end
   end
 end


### PR DESCRIPTION
#### Pull Request (PR) description

Since it's entirely possible to have a distinguished name of style

`o=My Cool Organization`

even for the root of the database, we really need to respect the proper
handling of spacey arguments to olcAccess (with the relevant quotes
around them).

#### This Pull Request (PR) fixes the following issues

n/a