### PR TITLE
Remove legacy facts from hiera configuration

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -7,10 +7,10 @@ defaults:
 
 hierarchy:
   - name: 'family/operatingsystemmajrelease'
-    path: 'os/%{facts.osfamily}/%{facts.operatingsystemmajrelease}.yaml'
+    path: 'os/%{facts.os.family}/%{facts.os.release.major}.yaml'
 
   - name: 'family'
-    path: 'os/%{facts.osfamily}.yaml'
+    path: 'os/%{facts.os.family}.yaml'
 
   - name: 'common'
     path: 'common.yaml'


### PR DESCRIPTION
When using Puppet without legacy facts, the module does not load the
os-specific configuration:

puppet config set include_legacy_facts false

Stop using legacy facts so that the proper configuration is loaded.
