### PR TITLE
Rename former herculesteam dependencies to reflect transfer to Vox

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,8 +1,8 @@
 fixtures:
   repositories:
     stdlib: 'https://github.com/puppetlabs/puppetlabs-stdlib.git'
-    augeasproviders_shellvar: 'https://github.com/hercules-team/augeasproviders_shellvar.git'
-    augeasproviders_core: 'https://github.com/hercules-team/augeasproviders_core.git'
+    augeasproviders_shellvar: 'https://github.com/voxpupuli/puppet-augeasproviders_shellvar.git'
+    augeasproviders_core: 'https://github.com/voxpupuli/puppet-augeasproviders_core.git'
     augeas_core: 'https://github.com/puppetlabs/puppetlabs-augeas_core.git'
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/metadata.json
+++ b/metadata.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "puppet/augeasproviders_shellvar",
-      "version_requirement": ">= 2.0.0 < 5.0.0"
+      "version_requirement": ">= 2.0.0 < 6.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -14,15 +14,15 @@
     },
     {
       "name": "puppetlabs/augeas_core",
-      "version_requirement": ">=1.0.0 < 2.0.0"
+      "version_requirement": ">= 1.0.0 < 2.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_core",
-      "version_requirement": ">=2.0.0 < 4.0.0"
+      "name": "puppet/augeasproviders_core",
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
-      "name": "herculesteam/augeasproviders_shellvar",
-      "version_requirement": ">=2.0.0 < 5.0.0"
+      "name": "puppet/augeasproviders_shellvar",
+      "version_requirement": ">= 2.0.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
#### Pull Request (PR) description
augeasproviders_core and augeasproviders_shellvar transfered to Vox:
https://github.com/voxpupuli/puppet-augeasproviders_core/commit/9328e3d1dcfb6e6e2c61daf1c4f7ae6c1305bbb6
https://github.com/voxpupuli/puppet-augeasproviders_shellvar/commit/9b1e4f4b2dc3c76ea1b53d098c79baa50d6bb6e0

This commit cleans up references to their former names.

#### This Pull Request (PR) fixes the following issues
n/a