### PR TITLE
Rework default database lifecycle on Debian

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,4 +1,7 @@
 # See README.md for details.
+# @param manage_policy_rc_d
+#   If set, manage /usr/sbin/policy-rc.d on Debian based operating systems to not automatically start the LDAP server
+#   when installing slapd.  This is required when preseeding the package with the no_configuration flag as we have to.
 class openldap::server (
   String[1] $package,
   String[1] $confdir,
@@ -30,6 +33,7 @@ class openldap::server (
   Optional[Stdlib::Absolutepath] $krb5_keytab_file  = undef,
   Optional[String] $ldap_config_backend             = undef,
   Optional[Boolean] $enable_memory_limit            = undef,
+  Boolean $manage_policy_rc_d                       = true,
 ) {
   include openldap::server::install
   include openldap::server::config

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -50,6 +50,18 @@ class openldap::server::config {
         variable => 'SLAPD_SERVICES',
         value    => $slapd_ldap_urls,
       }
+
+      # Debian configuration include database creation. We skip this with
+      # preseeding files so we need to manualy bootstrap cn=config (but not the
+      # databases).
+      exec { 'bootstrap cn=config':
+        command  => "/bin/sed -e 's/@BACKEND@/mdb/g' -e '/^# The database definition.$/q' /usr/share/slapd/slapd.init.ldif | /usr/sbin/slapadd -F ${openldap::server::confdir} -b cn=config",
+        provider => 'shell',
+        creates  => "${openldap::server::confdir}/cn=config.ldif",
+        user     => $openldap::server::owner,
+        group    => $openldap::server::group,
+        require  => File[$openldap::server::confdir],
+      }
     }
     'RedHat': {
       if versioncmp($facts['os']['release']['major'], '6') <= 0 {

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -49,7 +49,7 @@ define openldap::server::database (
   Class['openldap::server::service']
   -> Openldap::Server::Database[$title]
   -> Class['openldap::server']
-  if $title != 'dc=my-domain,dc=com' and fact('os.family') == 'Debian' {
+  if $title != 'dc=my-domain,dc=com' and fact('os.family') == 'RedHat' {
     Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap::Server::Database[$title]
   }
 

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -5,20 +5,22 @@ class openldap::server::install {
   contain openldap::utils
 
   if $facts['os']['family'] == 'Debian' {
-    $policy_rc_d = @(POLICY)
-      #!/bin/sh
-      if [ "$1" = "slapd" ]; then
-        exit 101
-      fi
-      exit 0
-      | POLICY
-    file { '/usr/sbin/policy-rc.d':
-      ensure  => 'file',
-      mode    => '0755',
-      owner   => 'root',
-      group   => 'root',
-      content => $policy_rc_d,
-      before  => Package[$openldap::server::package],
+    if $openldap::server::manage_policy_rc_d {
+      $policy_rc_d = @(POLICY)
+        #!/bin/sh
+        if [ "$1" = "slapd" ]; then
+          exit 101
+        fi
+        exit 0
+        | POLICY
+      file { '/usr/sbin/policy-rc.d':
+        ensure  => 'file',
+        mode    => '0755',
+        owner   => 'root',
+        group   => 'root',
+        content => $policy_rc_d,
+        before  => Package[$openldap::server::package],
+      }
     }
     file { '/var/cache/debconf/slapd.preseed':
       ensure  => file,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -5,12 +5,27 @@ class openldap::server::install {
   contain openldap::utils
 
   if $facts['os']['family'] == 'Debian' {
+    $policy_rc_d = @(POLICY)
+      #!/bin/sh
+      if [ "$1" = "slapd" ]; then
+        exit 101
+      fi
+      exit 0
+      | POLICY
+    file { '/usr/sbin/policy-rc.d':
+      ensure  => 'file',
+      mode    => '0755',
+      owner   => 'root',
+      group   => 'root',
+      content => $policy_rc_d,
+      before  => Package[$openldap::server::package],
+    }
     file { '/var/cache/debconf/slapd.preseed':
       ensure  => file,
       mode    => '0644',
       owner   => 'root',
       group   => 'root',
-      content => "slapd slapd/domain\tstring\tmy-domain.com\n",
+      content => "slapd slapd/no_configuration\tboolean\ttrue\n",
       before  => Package[$openldap::server::package],
     }
     $responsefile = '/var/cache/debconf/slapd.preseed'

--- a/manifests/server/slapdconf.pp
+++ b/manifests/server/slapdconf.pp
@@ -22,7 +22,7 @@ class openldap::server::slapdconf {
     fail 'You must specify a ssl_cert'
   }
 
-  if $facts['os']['family'] == 'Debian' or $facts['os']['family'] == 'RedHat' {
+  if $facts['os']['family'] == 'RedHat' {
     openldap::server::database { 'dc=my-domain,dc=com':
       ensure => absent,
     }

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -36,12 +36,15 @@ describe 'openldap::server::database' do
   end
 
   context 'without parameters' do
-    it 'creates a database' do
-      pp = <<-EOS
-      class { 'openldap::server': }
-      openldap::server::database { 'dc=foo,dc=com': }
+    let(:datadir) { '/var/lib/ldap' }
+    let(:pp) do
+      <<-EOS
+        class { 'openldap::server': }
+        openldap::server::database { 'dc=foo,dc=com': }
       EOS
+    end
 
+    it 'creates a database' do
       idempotent_apply(pp)
     end
 
@@ -49,6 +52,23 @@ describe 'openldap::server::database' do
       ldapsearch('-LLL -x -b dc=foo,dc=com') do |r|
         expect(r.stdout).to match(%r{dn: dc=foo,dc=com})
       end
+    end
+
+    it 'can dump the database' do
+      on default, 'slapcat -l /tmp/data.ldif'
+    end
+
+    it 'can restore the database' do
+      on default, puppet('resource service slapd ensure=stopped')
+      on default, "rm -r #{datadir}"
+      on default, "mkdir #{datadir}"
+      on default, 'slapadd -l /tmp/data.ldif'
+      on default, "chown -R ldap:ldap #{datadir}"
+      on default, puppet('resource service slapd ensure=running')
+    end
+
+    it 'has no change' do
+      apply_manifest(pp, catch_changes: true)
     end
   end
 

--- a/spec/acceptance/db_spec.rb
+++ b/spec/acceptance/db_spec.rb
@@ -37,6 +37,13 @@ describe 'openldap::server::database' do
 
   context 'without parameters' do
     let(:datadir) { '/var/lib/ldap' }
+    let(:user) do
+      if fact('os.family') == 'Debian'
+        'openldap'
+      else
+        'ldap'
+      end
+    end
     let(:pp) do
       <<-EOS
         class { 'openldap::server': }
@@ -63,7 +70,7 @@ describe 'openldap::server::database' do
       on default, "rm -r #{datadir}"
       on default, "mkdir #{datadir}"
       on default, 'slapadd -l /tmp/data.ldif'
-      on default, "chown -R ldap:ldap #{datadir}"
+      on default, "chown -R #{user}:#{user} #{datadir}"
       on default, puppet('resource service slapd ensure=running')
     end
 

--- a/spec/acceptance/openldap__server__access_spec.rb
+++ b/spec/acceptance/openldap__server__access_spec.rb
@@ -17,7 +17,9 @@ describe 'openldap::server::access' do
   after :all do
     pp = <<-EOS
       class { 'openldap::server': }
-      openldap::server::database { 'dc=example,dc=com': ensure => absent, }
+      openldap::server::database { 'dc=example,dc=com':
+        ensure => absent,
+      }
     EOS
 
     idempotent_apply(pp)

--- a/spec/classes/openldap_server_slapdconf_spec.rb
+++ b/spec/classes/openldap_server_slapdconf_spec.rb
@@ -14,7 +14,7 @@ describe 'openldap::server::slapdconf' do
         it { is_expected.to contain_class('openldap::server::slapdconf') }
 
         case facts[:osfamily]
-        when %r{Debian|RedHat}
+        when 'RedHat'
           it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
         else
           it { is_expected.not_to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }

--- a/spec/classes/openldap_server_spec.rb
+++ b/spec/classes/openldap_server_spec.rb
@@ -2,8 +2,6 @@
 
 require 'spec_helper'
 
-# rubocop:disable Style/IdenticalConditionalBranches
-# rubocop:disable RSpec/RepeatedExample
 describe 'openldap::server' do
   on_supported_os.each do |os, facts|
     context "on #{os}" do
@@ -47,8 +45,7 @@ describe 'openldap::server' do
                                                                     ssl_ca: nil)
             }
 
-            it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
-            it { is_expected.to have_openldap__server__database_resource_count(1) }
+            it { is_expected.to have_openldap__server__database_resource_count(0) }
           when 'RedHat'
             case facts[:operatingsystemmajrelease]
             when '5'
@@ -61,9 +58,6 @@ describe 'openldap::server' do
                                                                       ssl_key: nil,
                                                                       ssl_ca: nil)
               }
-
-              it { is_expected.to have_openldap__server__database_resource_count(1) }
-              it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
             else
               it {
                 is_expected.to contain_class('openldap::server').with(package: 'openldap-servers',
@@ -74,15 +68,13 @@ describe 'openldap::server' do
                                                                       ssl_key: nil,
                                                                       ssl_ca: nil)
               }
-
-              it { is_expected.to have_openldap__server__database_resource_count(1) }
-              it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
             end
+
+            it { is_expected.to have_openldap__server__database_resource_count(1) }
+            it { is_expected.to contain_openldap__server__database('dc=my-domain,dc=com').with(ensure: :absent) }
           end
         end
       end
     end
   end
 end
-# rubocop:enable Style/IdenticalConditionalBranches
-# rubocop:enable RSpec/RepeatedExample


### PR DESCRIPTION
When Debian install slapd, it configure it by default with a database that match the hostname unless overridden by a preseed file as we did before.  We did remove this database, however this has consequences on the first database created by the module and prevent it from being restored after being dumped (#366).

This PR remove database name customization and request `no_configuration` from the preseed file.  This requires us to bootstrap the `cn=config` database, but also prevent the package from installing correctly ([709472]).  To workaround this new issue, setup a `policy-rc.d` so that the service is not started at the post-install stage.  Because `policy-rc.d` is a system-wide script, we hope to cause conflicts with infrastructures which have a custom one.  We therefore provide a new flag to opt-out from managing this file from the repo.

Existing databases which cannot be dumped/restored are not fixed, but new deployment should not have this issue.

Fixes #366

[709472]:https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=709472