### PR TITLE
Support Ubuntu 22.04

### DIFF
--- a/data/os/Debian/22.04.yaml
+++ b/data/os/Debian/22.04.yaml
@@ -1,0 +1,2 @@
+---
+openldap::client::package: 'libldap-2.5-0'

--- a/metadata.json
+++ b/metadata.json
@@ -41,7 +41,8 @@
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
         "18.04",
-        "20.04"
+        "20.04",
+        "22.04"
       ]
     },
     {

--- a/spec/classes/openldap_client_install_spec.rb
+++ b/spec/classes/openldap_client_install_spec.rb
@@ -19,9 +19,16 @@ describe 'openldap::client::install' do
 
         case facts[:osfamily]
         when 'Debian'
-          it {
-            is_expected.to contain_package('libldap-2.4-2').with(ensure: :present)
-          }
+          case facts[:os]['release']['major']
+          when '22.04'
+            it {
+              is_expected.to contain_package('libldap-2.5-0').with(ensure: :present)
+            }
+          else
+            it {
+              is_expected.to contain_package('libldap-2.4-2').with(ensure: :present)
+            }
+          end
         when 'RedHat'
           it {
             is_expected.to contain_package('openldap').with(ensure: :present)

--- a/spec/classes/openldap_client_spec.rb
+++ b/spec/classes/openldap_client_spec.rb
@@ -15,13 +15,24 @@ describe 'openldap::client' do
 
         case facts[:osfamily]
         when 'Debian'
-          it {
-            is_expected.to contain_class('openldap::client').with(package: 'libldap-2.4-2',
-                                                                  file: '/etc/ldap/ldap.conf',
-                                                                  base: nil,
-                                                                  uri: nil,
-                                                                  tls_cacert: nil)
-          }
+          case facts[:os]['release']['major']
+          when '22.04'
+            it {
+              is_expected.to contain_class('openldap::client').with(package: 'libldap-2.5-0',
+                                                                    file: '/etc/ldap/ldap.conf',
+                                                                    base: nil,
+                                                                    uri: nil,
+                                                                    tls_cacert: nil)
+            }
+          else
+            it {
+              is_expected.to contain_class('openldap::client').with(package: 'libldap-2.4-2',
+                                                                    file: '/etc/ldap/ldap.conf',
+                                                                    base: nil,
+                                                                    uri: nil,
+                                                                    tls_cacert: nil)
+            }
+          end
         when 'RedHat'
           it {
             is_expected.to contain_class('openldap::client').with(package: 'openldap',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
This PR adds support for Ubuntu jammy 22.04.
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
```
E: Package 'libldap-2.4-2' has no installation candidate
Error: /Stage[main]/Openldap::Client::Install/Package[libldap-2.4-2]/ensure: change from 'purged' to 'present' failed: Execution of '/usr/bin/apt-get -q -y -o DPkg::Options::=--force-confold install libldap-2.4-2' returned 100: Reading package lists...
Building dependency tree...
Reading state information...
Package libldap-2.4-2 is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  libldap-common

E: Package 'libldap-2.4-2' has no installation candidate
```
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
