### PR TITLE
Add olcMultiProvider as a database config parameter

### DIFF
--- a/lib/puppet/provider/openldap.rb
+++ b/lib/puppet/provider/openldap.rb
@@ -166,6 +166,7 @@ class Puppet::Provider::Openldap < Puppet::Provider
       MirrorMode
       ModulePath
       Monitoring
+      MultiProvider
       Overlay
       PasswordCryptSaltFormat
       PidFile

--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -30,6 +30,7 @@ Puppet::Type.
       updateref = nil
       dboptions = {}
       mirrormode = nil
+      multiprovider = nil
       syncusesubentry = nil
       syncrepl = nil
       limits = []
@@ -83,6 +84,8 @@ Puppet::Type.
           end
         when %r{^olcMirrorMode: }
           mirrormode = line.split[1] == 'TRUE' ? :true : :false
+        when %r{^olcMultiProvider: }
+          multiprovider = line.split[1] == 'TRUE' ? :true : :false
         when %r{^olcSyncUseSubentry: }
           syncusesubentry = line.split(' ', 2)[1]
         when %r{^olcSyncrepl: }
@@ -119,6 +122,7 @@ Puppet::Type.
         updateref: updateref,
         dboptions: dboptions,
         mirrormode: mirrormode,
+        multiprovider: multiprovider,
         syncusesubentry: syncusesubentry,
         syncrepl: syncrepl,
         limits: limits,
@@ -257,6 +261,7 @@ Puppet::Type.
     end
     t << (resource[:syncrepl].map { |x| "olcSyncrepl: #{x}\n" }.join) if resource[:syncrepl]
     t << "olcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:mirrormode]
+    t << "olcMultiProvider: #{resource[:multiprovider] == :true ? 'TRUE' : 'FALSE'}\n" if resource[:multiprovider]
     t << "olcSyncUseSubentry: #{resource[:syncusesubentry]}\n" if resource[:syncusesubentry]
     t << "#{resource[:limits].map { |x| "olcLimits: #{x}" }.join("\n")}\n" if resource[:limits] && !resource[:limits].empty?
     t << "#{resource[:security].map { |k, v| "olcSecurity: #{k}=#{v}" }.join("\n")}\n" if resource[:security] && !resource[:security].empty?
@@ -341,6 +346,10 @@ Puppet::Type.
     @property_flush[:mirrormode] = value
   end
 
+  def multiprovider=(value)
+    @property_flush[:multiprovider] = value
+  end
+
   def syncusesubentry=(value)
     @property_flush[:syncusesubentry] = value
   end
@@ -408,6 +417,7 @@ Puppet::Type.
       t << "replace: olcSyncrepl\n#{resource[:syncrepl].map { |x| "olcSyncrepl: #{x}" }.join("\n")}\n-\n" if @property_flush[:syncrepl]
       t << "replace: olcUpdateref\nolcUpdateref: #{resource[:updateref]}\n-\n" if @property_flush[:updateref]
       t << "replace: olcMirrorMode\nolcMirrorMode: #{resource[:mirrormode] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:mirrormode]
+      t << "replace: olcMultiProvider\nolcMultiProvider: #{resource[:multiprovider] == :true ? 'TRUE' : 'FALSE'}\n-\n" if @property_flush[:multiprovider]
       t << "replace: olcSyncUseSubentry\nolcSyncUseSubentry: #{resource[:syncusesubentry]}\n-\n" if @property_flush[:syncusesubentry]
       t << "replace: olcLimits\n#{@property_flush[:limits].map { |x| "olcLimits: #{x}" }.join("\n")}\n-\n" if @property_flush[:limits]
       t << "replace: olcSecurity\n#{@property_flush[:security].map { |k, v| "olcSecurity: #{k}=#{v}" }.join("\n")}\n-\n" if @property_flush[:security]

--- a/lib/puppet/type/openldap_database.rb
+++ b/lib/puppet/type/openldap_database.rb
@@ -215,7 +215,12 @@ Puppet::Type.newtype(:openldap_database) do
   end
 
   newproperty(:mirrormode, boolean: true) do
-    desc 'This option puts a replica database into "mirror" mode'
+    desc 'This option puts a replica database into "mirror" mode, deprecated as of 2.5'
+    newvalues(:true, :false)
+  end
+
+  newproperty(:multiprovider, boolean: true) do
+    desc 'This option puts a replica database into "multiprovider" mode'
     newvalues(:true, :false)
   end
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -19,6 +19,7 @@ define openldap::server::database (
   Optional[String[1]]                           $synctype        = undef,
   # Synchronization options
   Optional[Boolean]                             $mirrormode      = undef,
+  Optional[Boolean]                             $multiprovider   = undef,
   Optional[String[1]]                           $syncusesubentry = undef,
   Optional[Variant[String[1],Array[String[1]]]] $syncrepl        = undef,
   Hash[
@@ -37,6 +38,10 @@ define openldap::server::database (
   ]                                             $security        = {},
 ) {
   include openldap::server
+
+  if $mirrormode != undef and $multiprovider != undef {
+    warning('multiprovider is an openldap2.5+ replacement for mirrormode.')
+  }
 
   $manage_directory = $backend ? {
     'monitor' => undef,
@@ -80,6 +85,7 @@ define openldap::server::database (
     dboptions       => $dboptions,
     synctype        => $synctype,
     mirrormode      => $mirrormode,
+    multiprovider   => $multiprovider,
     syncusesubentry => $syncusesubentry,
     syncrepl        => $syncrepl,
     limits          => $limits,

--- a/spec/defines/openldap_server_database_spec.rb
+++ b/spec/defines/openldap_server_database_spec.rb
@@ -52,6 +52,7 @@ describe 'openldap::server::database' do
                 },
                 synctype: 'inclusive',
                 mirrormode: true,
+                multiprovider: true,
                 syncusesubentry: 'wxw',
                 syncrepl: [
                   'rid=1 provider=ldap://localhost searchbase="dc=foo,dc=example,dc=com"',


### PR DESCRIPTION
#### Pull Request (PR) description
This puppet module has no awareness of `olcMultiProvider`, which was introduced in openldap 2.5 (circa 2021).  This PR adds that directive.

https://www.openldap.org/doc/admin25/appendix-upgrading.html :
"The `olcMirrorMode` attribute has been renamed to `olcMultiProvider`. Existing configurations will continue to work with the old parameter name, but it is advised to update to the new name as a part of the upgrade process."

While openldap 2.4 is officially EOL, this PR does not abandon 2.4.  We leave `olcMirrorMode` as an option, and duplicate it as a parallel option of `olcMultiProvider`, while adding a gentle warning if someone sets both options at the same time.

#### This Pull Request (PR) fixes the following issues
openldap 2.5 does an on-the-fly translation of any `olcMirrorMode` directives and returns `olcMultiProvider`.  Thus, each apply of the manifests currently yields `mirrormode: defined 'mirrormode' as 'true'` as it tries in vain to set the option.