### PR TITLE
Improve service bootstraping on Debian

### DIFF
--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -34,12 +34,16 @@ class openldap::server (
   Optional[Stdlib::Absolutepath] $krb5_keytab_file  = undef,
   Optional[String] $ldap_config_backend             = undef,
   Optional[Boolean] $enable_memory_limit            = undef,
-  Boolean $manage_policy_rc_d                       = true,
+  Optional[Boolean] $manage_policy_rc_d             = undef,
 ) {
   include openldap::server::install
   include openldap::server::config
   include openldap::server::service
   include openldap::server::slapdconf
+
+  unless $manage_policy_rc_d =~ Undef {
+    deprecation('manage_policy_rc_d', 'The manage_policy_rc_d parameter is deprecated and unused. It will be removed in a future version.')
+  }
 
   Class['openldap::server::install']
   -> Class['openldap::server::config']


### PR DESCRIPTION
Instead of relying on a fragile `policy-rc.d`, ensure the the systemd
unit is masked before installing the package. Puppet will unmask it when
it manage the service.

Fixes #386
