### PR TITLE
Remove deprecated code

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -453,7 +453,6 @@ The following parameters are available in the `openldap::server` class:
 
 * [`krb5_keytab_file`](#-openldap--server--krb5_keytab_file)
 * [`krb5_client_keytab_file`](#-openldap--server--krb5_client_keytab_file)
-* [`manage_policy_rc_d`](#-openldap--server--manage_policy_rc_d)
 * [`package`](#-openldap--server--package)
 * [`confdir`](#-openldap--server--confdir)
 * [`conffile`](#-openldap--server--conffile)
@@ -500,15 +499,6 @@ Data type: `Optional[Stdlib::Absolutepath]`
 
 if set, manage the env variable KRB5_CLIENT_KTNAME on Debian based operating systems. This is required when
 configuring sasl with backend GSSAPI
-
-Default value: `undef`
-
-##### <a name="-openldap--server--manage_policy_rc_d"></a>`manage_policy_rc_d`
-
-Data type: `Optional[Boolean]`
-
-If set, manage /usr/sbin/policy-rc.d on Debian based operating systems to not automatically start the LDAP server
-when installing slapd.  This is required when preseeding the package with the no_configuration flag as we have to.
 
 Default value: `undef`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -5,9 +5,6 @@
 # @param krb5_client_keytab_file
 #   if set, manage the env variable KRB5_CLIENT_KTNAME on Debian based operating systems. This is required when
 #   configuring sasl with backend GSSAPI
-# @param manage_policy_rc_d
-#   If set, manage /usr/sbin/policy-rc.d on Debian based operating systems to not automatically start the LDAP server
-#   when installing slapd.  This is required when preseeding the package with the no_configuration flag as we have to.
 class openldap::server (
   String[1] $package,
   String[1] $confdir,
@@ -41,16 +38,11 @@ class openldap::server (
   Optional[Stdlib::Absolutepath] $krb5_client_keytab_file  = undef,
   Optional[String] $ldap_config_backend             = undef,
   Optional[Boolean] $enable_memory_limit            = undef,
-  Optional[Boolean] $manage_policy_rc_d             = undef,
 ) {
   include openldap::server::install
   include openldap::server::config
   include openldap::server::service
   include openldap::server::slapdconf
-
-  unless $manage_policy_rc_d =~ Undef {
-    deprecation('manage_policy_rc_d', 'The manage_policy_rc_d parameter is deprecated and unused. It will be removed in a future version.')
-  }
 
   Class['openldap::server::install']
   -> Class['openldap::server::config']


### PR DESCRIPTION
In order to avoid forgetting to remove deprecated code in the next major release, this PR track all pending removals and will get merged when a new major release is ready to be cut.
