### PR TITLE
openldap_schema: fix replace w/o attribute types

### DIFF
--- a/lib/puppet/provider/openldap_schema/olc.rb
+++ b/lib/puppet/provider/openldap_schema/olc.rb
@@ -106,9 +106,11 @@ Puppet::Type.
       ldif.push('-')
     end
 
-    ldif.push('replace: olcAttributeTypes')
-    ldif.push(*attrType)
-    ldif.push('-')
+    unless attrType.empty?
+      ldif.push('replace: olcAttributeTypes')
+      ldif.push(*attrType)
+      ldif.push('-')
+    end
 
     ldif.push('replace: olcObjectClasses')
     ldif.push(*objClass)
@@ -154,9 +156,11 @@ Puppet::Type.
       new_ldif.push('-')
     end
 
-    new_ldif.push('replace: olcAttributeTypes')
-    new_ldif.push(*attrType)
-    new_ldif.push('-')
+    unless attrType.empty?
+      new_ldif.push('replace: olcAttributeTypes')
+      new_ldif.push(*attrType)
+      new_ldif.push('-')
+    end
 
     new_ldif.push('replace: olcObjectClasses')
     new_ldif.push(*objClass)


### PR DESCRIPTION
Check if the schema contains any attribute types
before adding the relevant `replace:` lines to the replace ldif.

This fixes failing updates on schemas without any attribute types.
