### PR TITLE
Fix unsafe interpolations

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -55,7 +55,7 @@ class openldap::server::config {
       # preseeding files so we need to manualy bootstrap cn=config (but not the
       # databases).
       exec { 'bootstrap cn=config':
-        command  => "/bin/sed -e 's/@BACKEND@/mdb/g' -e '/^# The database definition.$/q' /usr/share/slapd/slapd.init.ldif | /usr/sbin/slapadd -F ${openldap::server::confdir} -b cn=config",
+        command  => "/bin/sed -e 's/@BACKEND@/mdb/g' -e '/^# The database definition.$/q' /usr/share/slapd/slapd.init.ldif | /usr/sbin/slapadd -F ${openldap::server::confdir.shell_escape} -b cn=config", # lint:ignore:check_unsafe_interpolations
         provider => 'shell',
         creates  => "${openldap::server::confdir}/cn=config.ldif",
         user     => $openldap::server::owner,
@@ -146,7 +146,7 @@ class openldap::server::config {
       $ldif = file('openldap/cn-config.ldif')
       exec { 'bootstrap cn=config':
         path     => '/usr/local/sbin',
-        command  => "echo '${ldif}' | slapadd -n 0 -F ${openldap::server::confdir}",
+        command  => "echo ${ldif.shell_escape} | slapadd -n 0 -F ${openldap::server::confdir.shell_escape}", # lint:ignore:check_unsafe_interpolations
         creates  => "${openldap::server::confdir}/cn=config.ldif",
         provider => 'shell',
         user     => $openldap::server::owner,

--- a/manifests/server/install.pp
+++ b/manifests/server/install.pp
@@ -11,7 +11,7 @@ class openldap::server::install {
     # installation will succed. The module will then be able to tune slapd
     # accoding to the user needs and finally start (and unmak) the service.
     exec { 'mask-before-openldap-install':
-      command => "systemctl mask ${openldap::server::service}",
+      command => "systemctl mask ${openldap::server::service.shell_escape}", # lint:ignore:check_unsafe_interpolations
       unless  => 'test -x /usr/sbin/slapd',
       creates => "/etc/systemd/system/${openldap::server::service}.service",
       path    => '/bin:/usr/bin',


### PR DESCRIPTION
We now have puppet-lint-check_unsafe_interpolations and it detect some
issues.  Fix them.
