### PR TITLE
Create olcDbDirectory before its database and the start of slapd

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -52,10 +52,10 @@ define openldap::server::database (
   }
 
   Class['openldap::server::service']
-  -> Openldap::Server::Database[$title]
+  -> Openldap_database[$title]
   -> Class['openldap::server']
   if $title != 'dc=my-domain,dc=com' and fact('os.family') == 'RedHat' {
-    Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap::Server::Database[$title]
+    Openldap::Server::Database['dc=my-domain,dc=com'] -> Openldap_database[$title]
   }
 
   if $ensure == present and $backend != 'monitor' and $backend != 'config' and $backend != 'relay' and $backend != 'ldap' {
@@ -63,7 +63,7 @@ define openldap::server::database (
       ensure => directory,
       owner  => $openldap::server::owner,
       group  => $openldap::server::group,
-      before => Openldap_database[$title],
+      before => [Openldap_database[$title], Class['openldap::server::service']],
     }
   }
 

--- a/spec/defines/openldap_server_database_spec.rb
+++ b/spec/defines/openldap_server_database_spec.rb
@@ -21,6 +21,24 @@ describe 'openldap::server::database' do
             it {
               is_expected.to contain_openldap__server__database('dc=foo').with(directory: '/foo/bar')
             }
+
+            it {
+              # The slapd service must be started before we can make a database:
+              is_expected.to contain_class('openldap::server::service').
+                that_comes_before('Openldap_database[dc=foo]')
+            }
+
+            it {
+              # The containing directory for a database must exist before the database that it will contain:
+              is_expected.to contain_file('/foo/bar').
+                that_comes_before('Openldap_database[dc=foo]')
+            }
+
+            it {
+              # ... and "the specified olcDbDirectory must exist prior to starting slapd(8)":
+              is_expected.to contain_file('/foo/bar').
+                that_comes_before('Class[openldap::server::service]')
+            }
           end
 
           context 'with all parameters set' do


### PR DESCRIPTION
#### Pull Request (PR) description

There is an ordering in `manifests/server/database.pp`:

```puppet
  Class['openldap::server::service']
  -> Openldap::Server::Database[$title]
```

This is subtly bad.  The service (slapd) must be spun up before a database can be created.  That makes sense.  However, it means the service happens before `Openldap::Server::Database` ... and there is more going on in `manifests/server/database.pp` than just the `openldap_database` creation: there is also the creation of `File[$manage_directory]`.  In most folks' cases, this directory will be `/var/lib/ldap`, which happens to be installed by the RPM/dpkg package, so "you get it for free" / it already exists and the file creation doesn't need to be done by puppet.  However, if you set the directory to something else (that doesn't exist), you have a circular dependency problem.  `slapd` (the service) needs the database directory to exist before slapd starts up -> slapd is ordered before the database manifest -> the database manifest creates the database directory -> the database directory has to happen before the service.

Ultimately, the ordering is in error.  The service has to happen before `openldap_database` BUT NOT all of the ridealong items in `openldap::server::database`.  That breaks out of the dependency loop, and allows the directory creation to be marked as required before the Service is started.

Very likely, most folks are running one-DB-only in `/var/lib/ldap` (which matches most examples) and haven't tickled this issue.  That said, [OpenLDAP maintainers are advising you to use subdirectories](https://www.mail-archive.com/openldap-technical@openldap.org/msg28289.html) which puts this into the realm of needing to make a directory upon install.