### PR TITLE
Fix openldap_password function to avoid errors with latest Puppet 7

### DIFF
--- a/lib/puppet/functions/openldap_password.rb
+++ b/lib/puppet/functions/openldap_password.rb
@@ -26,16 +26,16 @@ Puppet::Functions.create_function(:openldap_password) do
   def generate_password(secret, scheme = 'SSHA')
     case scheme[%r{([A-Z,0-9]+)}, 1]
     when 'CRYPT'
-      salt = call_function(:fqdn_rand_string, 2)
+      salt = call_function('fqdn_rand_string', 2)
       password = "{CRYPT}#{secret.crypt(salt)}"
     when 'MD5'
       password = "{MD5}#{Digest::MD5.hexdigest(secret)}"
     when 'SMD5'
-      salt = call_function(:fqdn_rand_string, 8)
+      salt = call_function('fqdn_rand_string', 8)
       md5_hash_with_salt = "#{Digest::MD5.digest(secret + salt)}#{salt}"
       password = "{SMD5}#{[md5_hash_with_salt].pack('m').delete("\n")}"
     when 'SSHA'
-      salt = call_function(:fqdn_rand_string, 8)
+      salt = call_function('fqdn_rand_string', 8)
       password = "{SSHA}#{Base64.encode64("#{Digest::SHA1.digest(secret + salt)}#{salt}").chomp}"
     when 'SHA'
       password = "{SHA}#{Digest::SHA1.hexdigest(secret)}"

--- a/spec/functions/openldap_password_spec.rb
+++ b/spec/functions/openldap_password_spec.rb
@@ -11,16 +11,16 @@ describe :openldap_password do
   end
 
   it 'generates SSHA password with only a secret' do
-    allow(subject.func).to receive(:call_function).with(:fqdn_rand_string, 8).and_return('abcdefgh')
+    allow(subject.func).to receive(:call_function).with('fqdn_rand_string', 8).and_return('abcdefgh')
     is_expected.to run.with_params('foo').and_return('{SSHA}3RXLE64s+3ytIRdJYu9eoU8O/alhYmNkZWZnaA==')
-    expect(subject.func).to have_received(:call_function).with(:fqdn_rand_string, 8)
+    expect(subject.func).to have_received(:call_function).with('fqdn_rand_string', 8)
   end
 
   context 'when given a secret and a scheme' do
     it 'generates CRYPT password' do
-      allow(subject.func).to receive(:call_function).with(:fqdn_rand_string, 2).and_return('ab')
+      allow(subject.func).to receive(:call_function).with('fqdn_rand_string', 2).and_return('ab')
       is_expected.to run.with_params('foo', 'CRYPT').and_return('{CRYPT}abQ9KY.KfrYrc')
-      expect(subject.func).to have_received(:call_function).with(:fqdn_rand_string, 2)
+      expect(subject.func).to have_received(:call_function).with('fqdn_rand_string', 2)
     end
 
     it 'generates MD5 password' do
@@ -28,15 +28,15 @@ describe :openldap_password do
     end
 
     it 'generates SMD5 password' do
-      allow(subject.func).to receive(:call_function).with(:fqdn_rand_string, 8).and_return('abcdefgh')
+      allow(subject.func).to receive(:call_function).with('fqdn_rand_string', 8).and_return('abcdefgh')
       is_expected.to run.with_params('foo', 'SMD5').and_return('{SMD5}NAYSvQYSIRYBLCM8U6MUc2FiY2RlZmdo')
-      expect(subject.func).to have_received(:call_function).with(:fqdn_rand_string, 8)
+      expect(subject.func).to have_received(:call_function).with('fqdn_rand_string', 8)
     end
 
     it 'generates SSHA password' do
-      allow(subject.func).to receive(:call_function).with(:fqdn_rand_string, 8).and_return('abcdefgh')
+      allow(subject.func).to receive(:call_function).with('fqdn_rand_string', 8).and_return('abcdefgh')
       is_expected.to run.with_params('foo', 'SSHA').and_return('{SSHA}3RXLE64s+3ytIRdJYu9eoU8O/alhYmNkZWZnaA==')
-      expect(subject.func).to have_received(:call_function).with(:fqdn_rand_string, 8)
+      expect(subject.func).to have_received(:call_function).with('fqdn_rand_string', 8)
     end
 
     it 'generates SHA password' do


### PR DESCRIPTION
Errors:

```
Error: Could not retrieve catalog from remote server: Error 500 on SERVER: Server Error: Evaluation Error: Error while evaluating a Function Call, failed to coerce org.jruby.RubySymbol to java.lang.String
```

Stack trace on puppetserver:

```
/etc/puppetlabs/code/environments/test/modules/openldap/lib/puppet/functions/openldap_password.rb:38:in `generate_password'
```
