### PR TITLE
fix: correct syncrepl option passed to openldap_database if type Array

### DIFF
--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -67,6 +67,13 @@ define openldap::server::database (
     }
   }
 
+  # Flatten syncrepl if passed as an Array
+  if $syncrepl {
+    $_final_syncrepl = Array($syncrepl).join(' ')
+  } else {
+    $_final_syncrepl = undef
+  }
+
   openldap_database { $title:
     ensure          => $ensure,
     suffix          => $suffix,
@@ -87,7 +94,7 @@ define openldap::server::database (
     mirrormode      => $mirrormode,
     multiprovider   => $multiprovider,
     syncusesubentry => $syncusesubentry,
-    syncrepl        => $syncrepl,
+    syncrepl        => $_final_syncrepl,
     limits          => $limits,
     security        => $security,
   }


### PR DESCRIPTION
#### Pull Request (PR) description
The defined type `openldap::server::database` shows that an Array can be passed to the `syncrepl` parameter,. However, if you pass an Array of Strings, an error is thrown because it shows the provider sending an array of individual parameters instead of what it is expecting, which is a String of those parameters joined with a single space. This fix modifies the defined type to send the provider what it expects. Another fix would be to make the provider treat Array values differently, but I am not fluent in Ruby, so I instead went this route.

#### This Pull Request (PR) fixes the following issues
Fixes #221

This should make an example database as follows to be configured as expected:

```yaml
openldap::server::databases:
  'dc=example,dc=org':
    ensure: 'present'
    backend: 'bdb'
    dboptions:
      cachesize: '10000'
      checkpoint: '128 15'
      dbconfig:
        - set_cachesize 0 268435456 1
        - set_lg_regionmax 262144
        - set_lg_bsize 2097152
    rootdn: 'cn=Manager,dc=example,dc=org'
    rootpw: 'somesecretvaluehere'
    sizelimit: 'unlimited'
    syncrepl:
      - 'rid=102'
      - 'provider=ldaps://ldap.example.org:636'
      - 'searchbase=dc=example,dc=org'
      - 'type=refreshOnly'
      - 'interval=60'
      # The first 10 tries will occur once every 60 seconds, followed by 3 attempts every 300 seconds
      - 'retry="60 10 300 3"'
      - 'filter=(objectClass=*)'
      - 'scope=sub'
      - 'schemachecking=off'
      - 'bindmethod=simple'
      - 'binddn=cn=syncrepl,dc=example,dc=org'
      - 'credentials=somesecretvaluehere'
      - 'tls_cacert=/etc/pki/tls/certs/ca-bundle.crt'
    timelimit: 'unlimited'
```