### PR TITLE
Rework `openldap::server::database` interface for the `limits` parameter

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -51,6 +51,7 @@
 * [`Openldap::Access_title`](#Openldap--Access_title): A valid title for an openldap::server::access resource
 * [`Openldap::Attribute`](#Openldap--Attribute): An LDAP attribute in the form "key: value"
 * [`Openldap::Attributes`](#Openldap--Attributes): A set of LDAP attributes
+* [`Openldap::Limits`](#Openldap--Limits): Limits for clients
 * [`Openldap::Syncrepl`](#Openldap--Syncrepl): Parameters for database replication consumers
 * [`Openldap::Tls_moznss_compatibility`](#Openldap--Tls_moznss_compatibility): The list of possible values TLS_MOZNSS_COMPATIBILITY can have (based on the man page), and an 'absent' (a puppet directive to remove an exist
 
@@ -1016,11 +1017,11 @@ Default value: `undef`
 
 ##### <a name="-openldap--server--database--limits"></a>`limits`
 
-Data type: `Array[String[1]]`
+Data type: `Openldap::Limits`
 
 
 
-Default value: `[]`
+Default value: `{}`
 
 ##### <a name="-openldap--server--database--dboptions"></a>`dboptions`
 
@@ -1799,6 +1800,34 @@ Variant[Hash[
     Openldap::Attribute,
     1,
   ], Openldap::Attribute]
+```
+
+### <a name="Openldap--Limits"></a>`Openldap::Limits`
+
+Limits for clients
+
+* **See also**
+  * https://www.openldap.org/doc/admin26/limits.html
+
+Alias of
+
+```puppet
+Hash[String[1], Struct[
+    {
+      # Specify time limits
+      Optional['time']           => Variant[Integer[0], Enum['unlimited']],
+      Optional['time.soft']      => Variant[Integer[0], Enum['unlimited']],
+      Optional['time.hard']      => Variant[Integer[0], Enum['unlimited']],
+      # Specifying size limits
+      Optional['size']           => Variant[Integer[0], Enum['unlimited']],
+      Optional['size.soft']      => Variant[Integer[0], Enum['unlimited']],
+      Optional['size.hard']      => Variant[Integer[0], Enum['unlimited']],
+      Optional['size.unchecked'] => Variant[Integer[0], Enum['disabled', 'unlimited']],
+      # Size limits and Paged Results
+      Optional['size.pr']        => Variant[Integer[0], Enum['noEstimate', 'unlimited']],
+      Optional['size.prtotal']   => Variant[Integer[0], Enum['disabled', 'unlimited']],
+    },
+  ]]
 ```
 
 ### <a name="Openldap--Syncrepl"></a>`Openldap::Syncrepl`

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -13,7 +13,7 @@ define openldap::server::database (
   Optional[String[1]]                           $dbmaxsize       = undef,
   Optional[String[1]]                           $timelimit       = undef,
   Optional[String[1]]                           $updateref       = undef,
-  Array[String[1]]                              $limits          = [],
+  Openldap::Limits                              $limits          = {},
   # BDB/HDB options
   Hash[String[1],Variant[String[1],Array[String[1]]]] $dboptions = {},
   Optional[String[1]]                           $synctype        = undef,
@@ -96,7 +96,7 @@ define openldap::server::database (
         }
       }.flatten.join(' ')
     },
-    limits          => $limits,
+    limits          => $limits.map |$selector, $limits| { "${selector} ${limits.map |$k, $v| { "${k}=${v}" }.join(' ')}" },
     security        => $security,
   }
 }

--- a/spec/defines/openldap_server_database_spec.rb
+++ b/spec/defines/openldap_server_database_spec.rb
@@ -37,11 +37,11 @@ describe 'openldap::server::database' do
                 dbmaxsize: '10000',
                 timelimit: '10000',
                 updateref: 'default_updateref',
-                limits: [
-                  'dn.exact="cn=anyuser,dc=example,dc=org" size=100000',
-                  'dn.exact="cn=personnel,dc=example,dc=org" size=unlimited',
-                  'dn.exact="cn=dirsync,dc=example,dc=org" size=100000'
-                ],
+                limits: {
+                  'dn.exact="cn=anyuser,dc=example,dc=org"'   => { size: 100_000 },
+                  'dn.exact="cn=personnel,dc=example,dc=org"' => { size: 'unlimited' },
+                  'dn.exact="cn=dirsync,dc=example,dc=org"'   => { size: 100_000 }
+                },
                 dboptions: {
                   config: [
                     'set_cachesize 0 10485760 0',

--- a/types/limits.pp
+++ b/types/limits.pp
@@ -1,0 +1,22 @@
+# @summary Limits for clients
+#
+# @see https://www.openldap.org/doc/admin26/limits.html
+type Openldap::Limits = Hash[
+  String[1],
+  Struct[
+    {
+      # Specify time limits
+      Optional['time']           => Variant[Integer[0], Enum['unlimited']],
+      Optional['time.soft']      => Variant[Integer[0], Enum['unlimited']],
+      Optional['time.hard']      => Variant[Integer[0], Enum['unlimited']],
+      # Specifying size limits
+      Optional['size']           => Variant[Integer[0], Enum['unlimited']],
+      Optional['size.soft']      => Variant[Integer[0], Enum['unlimited']],
+      Optional['size.hard']      => Variant[Integer[0], Enum['unlimited']],
+      Optional['size.unchecked'] => Variant[Integer[0], Enum['disabled', 'unlimited']],
+      # Size limits and Paged Results
+      Optional['size.pr']        => Variant[Integer[0], Enum['noEstimate', 'unlimited']],
+      Optional['size.prtotal']   => Variant[Integer[0], Enum['disabled', 'unlimited']],
+    },
+  ],
+]


### PR DESCRIPTION
Similar to the work on the `syncrepl` parameter, adjust the interface to
use a well-defined Puppet structure to help writing manifests easier to
read.

### Updating your configuration

If you are using the `limits` parameter, you need to update your manifests when updating the module.

Transform a configuration like:

```puppet
openldap::server::database { 'dc=example,dc=com':
  ensure => present,
  limits => [
    'dn.exact="cn=anyuser,dc=example,dc=org" size=100000',
    'dn.exact="cn=personnel,dc=example,dc=org" size=unlimited',
    'dn.exact="cn=dirsync,dc=example,dc=org" size=100000',
  ],
}
```

Into this:

```puppet
openldap::server::database { 'dc=example,dc=com':
  ensure => present,
  limits => {
    'dn.exact="cn=anyuser,dc=example,dc=org"'   => {
      size => 100000,
    },
    'dn.exact="cn=personnel,dc=example,dc=org"' => {
      size => 'unlimited',
    },
    'dn.exact="cn=dirsync,dc=example,dc=org"'   => {
      size => 100000,
    },
  },
}
```