### PR TITLE
Allow for an outsider package on RHEL8+

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -120,14 +120,16 @@ class openldap::server::config {
         }
       }
       if versioncmp($facts['os']['release']['major'], '8') >= 0 {
-        systemd::dropin_file { 'puppet.conf':
-          unit    => "${openldap::server::service}.service",
-          content => join([
-              '[Service]',
-              'EnvironmentFile=/etc/sysconfig/slapd',
-              'ExecStart=',
-              "ExecStart=/usr/sbin/slapd -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
-          ], "\n"),
+        if $openldap::server::package == 'openldap-servers' {
+          systemd::dropin_file { 'puppet.conf':
+            unit    => "${openldap::server::service}.service",
+            content => join([
+                '[Service]',
+                'EnvironmentFile=/etc/sysconfig/slapd',
+                'ExecStart=',
+                "ExecStart=/usr/sbin/slapd -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
+            ], "\n"),
+          }
         }
       }
     }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -119,17 +119,16 @@ class openldap::server::config {
           value    => $slapd_ldap_urls,
         }
       }
-      if versioncmp($facts['os']['release']['major'], '8') >= 0 {
-        if $openldap::server::package == 'openldap-servers' {
-          systemd::dropin_file { 'puppet.conf':
-            unit    => "${openldap::server::service}.service",
-            content => join([
-                '[Service]',
-                'EnvironmentFile=/etc/sysconfig/slapd',
-                'ExecStart=',
-                "ExecStart=/usr/sbin/slapd -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
-            ], "\n"),
-          }
+      if versioncmp($facts['os']['release']['major'], '8') >= 0 and $openldap::server::package == 'openldap-servers' {
+        systemd::manage_dropin { 'puppet.conf':
+          unit          => "${openldap::server::service}.service",
+          service_entry => {
+            'EnvironmentFile' => '/etc/sysconfig/slapd',
+            'ExecStart'       => [
+              '',
+              "/usr/sbin/slapd -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
+            ],
+          },
         }
       }
     }

--- a/spec/classes/openldap_server_config_spec.rb
+++ b/spec/classes/openldap_server_config_spec.rb
@@ -15,6 +15,12 @@ describe 'openldap::server::config' do
         it { is_expected.not_to contain_openldap__globalconf('TLSCertificateFile') }
         it { is_expected.not_to contain_openldap__globalconf('TLSCertificateKeyFile') }
         it { is_expected.not_to contain_openldap__globalconf('TLSCACertificateFile') }
+
+        if (facts[:os]['family'] == 'RedHat') && (facts[:os]['release']['major'].to_i >= 8)
+          it { is_expected.to contain_systemd__dropin_file('puppet.conf') }
+        else
+          it { is_expected.not_to contain_systemd__dropin_file('puppet.conf') }
+        end
       end
     end
 
@@ -33,6 +39,22 @@ describe 'openldap::server::config' do
         it { is_expected.to compile.with_all_deps }
         it { is_expected.to contain_class('openldap::server::config') }
         it { is_expected.to contain_shellvar('krb5_client_ktname').with(value: '/etc/krb5.keytab') }
+      end
+    end
+
+    context "on #{os} with nonstandard package" do
+      let(:facts) do
+        facts
+      end
+
+      let(:pre_condition) do
+        "class {'openldap::server': package => 'some-openldap-clone', }"
+      end
+
+      context 'with some-openldap-clone' do
+        it { is_expected.to compile.with_all_deps }
+        it { is_expected.to contain_class('openldap::server::config') }
+        it { is_expected.not_to contain_systemd__dropin_file('puppet.conf') }
       end
     end
   end


### PR DESCRIPTION
In `openldap::server::config`, if redhat 8-or-newer, there's a `systemd::dropin_file` that makes a startup file so you can tune the user `/usr/sbin/slapd` runs as.

The problem is, there's a subtle assumption here that your binary is actually `/usr/sbin/slapd`.  Ever since RHEL7.4, the `openldap-servers` has been deprecated, so some of us have pivoted over to using Symas' packages, which installs everything in `/opt`.  That is, Puppet says to use `/usr/sbin/slapd` "because you're on RHEL8" (wrong), instead of "because you're using a RHEL-styled package".  So this makes it more explicit why you're using this file, and takes it away when you use a different package.

"Why not just symlink slapd?"  Tried, didn't work.  systemd was not pleased by this.
"Why not just make the fully-pathed slapd executable be a parameter which defaults to `/usr/sbin/slapd`".  Thought about it.  But for the most part I'm thinking "this file adds unnecessary noise" so I went for the path of least surprise and removed it.