### PR TITLE
Allow RHEL8+ to configure the slapd binary when needed

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -474,6 +474,7 @@ The following parameters are available in the `openldap::server` class:
 * [`databases`](#-openldap--server--databases)
 * [`ldap_ifs`](#-openldap--server--ldap_ifs)
 * [`ldaps_ifs`](#-openldap--server--ldaps_ifs)
+* [`slapd_path`](#-openldap--server--slapd_path)
 * [`slapd_params`](#-openldap--server--slapd_params)
 * [`ldap_port`](#-openldap--server--ldap_port)
 * [`ldap_address`](#-openldap--server--ldap_address)
@@ -651,6 +652,14 @@ Data type: `Array[String[1]]`
 
 
 Default value: `[]`
+
+##### <a name="-openldap--server--slapd_path"></a>`slapd_path`
+
+Data type: `Optional[Stdlib::Absolutepath]`
+
+
+
+Default value: `undef`
 
 ##### <a name="-openldap--server--slapd_params"></a>`slapd_params`
 

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -27,6 +27,7 @@ class openldap::server (
   Hash $databases                                   = {},
   Array[String[1]] $ldap_ifs                        = ['/'],
   Array[String[1]] $ldaps_ifs                       = [],
+  Optional[Stdlib::Absolutepath] $slapd_path        = undef,
   Optional[String] $slapd_params                    = undef,
   Optional[Stdlib::Port] $ldap_port                 = undef,
   Optional[Stdlib::IP::Address] $ldap_address       = undef,

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -126,14 +126,15 @@ class openldap::server::config {
         } else {
           $real_slapd_path = '/usr/sbin/slapd'
         }
-        systemd::dropin_file { 'puppet.conf':
-          unit    => "${openldap::server::service}.service",
-          content => join([
-              '[Service]',
-              'EnvironmentFile=/etc/sysconfig/slapd',
-              'ExecStart=',
-              "ExecStart=${real_slapd_path} -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
-          ], "\n"),
+        systemd::manage_dropin { 'puppet.conf':
+          unit          => "${openldap::server::service}.service",
+          service_entry => {
+            'EnvironmentFile' => '/etc/sysconfig/slapd',
+            'ExecStart'       => [
+              '',
+              "${real_slapd_path} -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
+            ],
+          },
         }
       }
     }

--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -2,6 +2,7 @@
 class openldap::server::config {
   include openldap::server
 
+  $slapd_path          = $openldap::server::slapd_path
   $slapd_params        = $openldap::server::slapd_params
   $owner               = $openldap::server::owner
   $group               = $openldap::server::group
@@ -120,13 +121,18 @@ class openldap::server::config {
         }
       }
       if versioncmp($facts['os']['release']['major'], '8') >= 0 {
+        if $slapd_path != undef {
+          $real_slapd_path = $slapd_path
+        } else {
+          $real_slapd_path = '/usr/sbin/slapd'
+        }
         systemd::dropin_file { 'puppet.conf':
           unit    => "${openldap::server::service}.service",
           content => join([
               '[Service]',
               'EnvironmentFile=/etc/sysconfig/slapd',
               'ExecStart=',
-              "ExecStart=/usr/sbin/slapd -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
+              "ExecStart=${real_slapd_path} -u ${openldap::server::owner} -h \${SLAPD_URLS} \$SLAPD_OPTIONS",
           ], "\n"),
         }
       }

--- a/spec/classes/openldap_server_config_spec.rb
+++ b/spec/classes/openldap_server_config_spec.rb
@@ -55,7 +55,7 @@ describe 'openldap::server::config' do
 
       case facts[:os]['family']
       when 'RedHat'
-        if (facts[:os]['release']['major'].to_i >= 8)
+        if facts[:os]['release']['major'].to_i >= 8
           it {
             is_expected.to contain_systemd__dropin_file('puppet.conf').with_content('^ExecStart=/some/odd/path')
           }


### PR DESCRIPTION
In `openldap::server::config`, if redhat 8-or-newer, there's a `systemd::dropin_file` that makes a startup file so you can tune the user `/usr/sbin/slapd` runs as.

The problem is, there's a subtle assumption here that your binary is actually `/usr/sbin/slapd`. Ever since RHEL7.4, the `openldap-servers` has been deprecated, so some of us have pivoted over to using Symas' packages, which installs everything in `/opt`. That is, Puppet says to use `/usr/sbin/slapd` "because you're on RHEL8" (wrong), instead of "because you're using a RHEL-styled package".

Supersedes #429 .  429 is a better fix by dropping the systemd hack file altogether when you use a non-RH package.  As we roll towards RHEL9 and everyone is having to use non-RH packages, more folks will see that, but minimally this starts unblocking the path to get there.

Closes #429