### PR TITLE
Add `PPolicyCheckModule` as a valid database/overlay option

### DIFF
--- a/lib/puppet/provider/openldap.rb
+++ b/lib/puppet/provider/openldap.rb
@@ -212,6 +212,7 @@ class Puppet::Provider::Openldap < Puppet::Provider
       DbMaxSize
       DbMode
       DbSearchStack
+      PPolicyCheckModule
       PPolicyDefault
       PPolicyHashCleartext
       PPolicyForwardUpdates


### PR DESCRIPTION
#### Pull Request (PR) description

https://www.openldap.org/doc/admin26/guide.html#ppolicy%20overlay
In upgrading openldap 2.5->2.6, you have to make ppolicy adjustments.
The upgrade guide is documented in "assumes ldap expert-ese", but from [an older bug](https://bugs.openldap.org/show_bug.cgi?id=9666#c1):

* You add (one config-overlay) `olcPPolicyCheckModule`=`somemodule.so`
* You add (any policies using) `pwdUseCheckModule`=`TRUE`
* You remove (any policies using) `pwdCheckModule`=`somemodule.so`

... and puppet doesn't know about `PPolicyCheckModule`.  So here we are.

It's lumped in with a lot of other attributes, but it has sibling attrs from https://www.openldap.org/software/man.cgi?query=slapo-ppolicy&manpath=OpenLDAP+2.6-Release
