### PR TITLE
Add olcChainConfig overlay

### DIFF
--- a/spec/unit/puppet/provider/openldap_overlay/olc_spec.rb
+++ b/spec/unit/puppet/provider/openldap_overlay/olc_spec.rb
@@ -8,7 +8,6 @@ describe Puppet::Type.type(:openldap_overlay).provider(:olc) do
     let(:params) do
       {
         title: 'memberof on dc=example,dc=com',
-        name: 'memberof on dc=example,dc=com',
         overlay: 'memberof',
         suffix: 'dc=example,dc=com',
         provider: described_class.name,

--- a/spec/unit/puppet/provider/openldap_overlay/olc_spec.rb
+++ b/spec/unit/puppet/provider/openldap_overlay/olc_spec.rb
@@ -56,6 +56,48 @@ describe Puppet::Type.type(:openldap_overlay).provider(:olc) do
         )
       end
     end
+
+    describe 'chain' do
+      before do
+        slapcat_overlay_output = <<~OUTPUT
+          dn: olcOverlay={0}chain,olcDatabase={-1}frontend,cn=config
+          objectClass: olcConfig
+          objectClass: olcOverlayConfig
+          objectClass: olcChainConfig
+          olcOverlay: {0}chain
+          olcChainCacheURI: FALSE
+          olcChainMaxReferralDepth: 1
+          olcChainReturnError: TRUE
+        OUTPUT
+        slapcat_db_output = <<~OUTPUT
+          dn: olcDatabase={-1}frontend,cn=config
+          objectClass: olcDatabaseConfig
+          objectClass: olcFrontendConfig
+          olcDatabase: {-1}frontend
+        OUTPUT
+        allow(described_class).to receive(:slapcat).with(
+          '(olcOverlay=*)'
+        ).and_return(slapcat_overlay_output)
+        allow(described_class).to receive(:slapcat).with(
+          '(olcDatabase={-1}frontend)'
+        ).and_return(slapcat_db_output)
+      end
+
+      it 'reads a chain object' do
+        expect(described_class.instances.size).to eq(1)
+        expect(described_class.instances[0].name).to eq('chain on cn=frontend')
+        expect(described_class.instances[0].overlay).to eq('chain')
+        expect(described_class.instances[0].suffix).to eq('cn=frontend')
+        expect(described_class.instances[0].index).to eq(0)
+        expect(described_class.instances[0].options).to eq(
+          {
+            'olcChainCacheURI'         => 'FALSE',
+            'olcChainMaxReferralDepth' => '1',
+            'olcChainReturnError'      => 'TRUE',
+          }
+        )
+      end
+    end
   end
 
   describe 'creating overlay' do
@@ -86,11 +128,14 @@ describe Puppet::Type.type(:openldap_overlay).provider(:olc) do
       allow(tmpfile).to receive(:path).and_return(tmpfile_path)
       allow(IO).to receive(:read).with(tmpfile_path).and_return(tmpfile_content)
       allow(Puppet).to receive(:debug).with(tmpfile_content)
-      allow(provider).to receive(:getDn).and_return('dc=example,dc=com')
       allow(provider).to receive(:ldapmodify)
     end
 
     describe 'when creating' do
+      before do
+        allow(provider).to receive(:getDn).and_return('dc=example,dc=com')
+      end
+
       it 'creates an overlay' do
         provider.create
         expect(tmpfile).to have_received(:<<).with("dn: olcOverlay=memberof,dc=example,dc=com\n")
@@ -101,6 +146,10 @@ describe Puppet::Type.type(:openldap_overlay).provider(:olc) do
     end
 
     describe 'with smbk5pwd' do
+      before do
+        allow(provider).to receive(:getDn).and_return('dc=example,dc=com')
+      end
+
       let(:params) do
         {
           title: 'smbk5pwd on dc=example,dc=com',
@@ -117,6 +166,29 @@ describe Puppet::Type.type(:openldap_overlay).provider(:olc) do
           expect(tmpfile).to have_received(:<<).with("objectClass: olcSmbK5PwdConfig\n")
           expect(tmpfile).to have_received(:<<).with("olcOverlay: smbk5pwd\n")
           expect(tmpfile).to have_received(:<<).with("olcSmbK5PwdEnable: samba\nolcSmbK5PwdEnable: shadow\n")
+          expect(provider).to have_received(:ldapmodify)
+        end
+      end
+    end
+
+    describe 'with chain' do
+      let(:params) do
+        {
+          title: 'chain on cn=frontend',
+          suffix: 'cn=frontend',
+          options: {
+            'olcChainMaxReferralDepth' => '1',
+          },
+        }
+      end
+
+      describe 'when creating' do
+        it 'creates an overlay' do
+          provider.create
+          expect(tmpfile).to have_received(:<<).with("dn: olcOverlay=chain,olcDatabase={-1}frontend,cn=config\n")
+          expect(tmpfile).to have_received(:<<).with("objectClass: olcChainConfig\n")
+          expect(tmpfile).to have_received(:<<).with("olcOverlay: chain\n")
+          expect(tmpfile).to have_received(:<<).with("olcChainMaxReferralDepth: 1\n")
           expect(provider).to have_received(:ldapmodify)
         end
       end

--- a/spec/unit/puppet/provider/openldap_overlay/olc_spec.rb
+++ b/spec/unit/puppet/provider/openldap_overlay/olc_spec.rb
@@ -4,66 +4,68 @@ require 'spec_helper'
 
 # rubocop:disable RSpec/MultipleMemoizedHelpers
 describe Puppet::Type.type(:openldap_overlay).provider(:olc) do
-  let(:params) do
-    {
-      title: 'memberof on dc=example,dc=com',
-      name: 'memberof on dc=example,dc=com',
-      overlay: 'memberof',
-      suffix: 'dc=example,dc=com',
-      provider: described_class.name,
-    }
-  end
-
-  let(:resource) do
-    Puppet::Type.type(:openldap_overlay).new(params)
-  end
-
-  let(:provider) do
-    resource.provider
-  end
-
-  let(:tmpfile) { instance_spy(Tempfile) }
-  let(:tmpfile_path) { double }
-  let(:tmpfile_content) { double }
-
-  before do
-    allow(provider).to receive(:slapcat).and_return('foo')
-    allow(Tempfile).to receive(:new).and_return(tmpfile)
-    allow(tmpfile).to receive(:path).and_return(tmpfile_path)
-    allow(IO).to receive(:read).with(tmpfile_path).and_return(tmpfile_content)
-    allow(Puppet).to receive(:debug).with(tmpfile_content)
-    allow(provider).to receive(:getDn).and_return('dc=example,dc=com')
-    allow(provider).to receive(:ldapmodify)
-  end
-
-  describe 'when creating' do
-    it 'creates an overlay' do
-      provider.create
-      expect(tmpfile).to have_received(:<<).with("dn: olcOverlay=memberof,dc=example,dc=com\n")
-      expect(tmpfile).to have_received(:<<).with("objectClass: olcMemberOf\n")
-      expect(tmpfile).to have_received(:<<).with("olcOverlay: memberof\n")
-      expect(provider).to have_received(:ldapmodify)
-    end
-  end
-
-  describe 'with smbk5pwd' do
+  describe 'creating overlay' do
     let(:params) do
       {
-        title: 'smbk5pwd on dc=example,dc=com',
-        options: {
-          'olcSmbK5PwdEnable' => %w[samba shadow],
-        },
+        title: 'memberof on dc=example,dc=com',
+        name: 'memberof on dc=example,dc=com',
+        overlay: 'memberof',
+        suffix: 'dc=example,dc=com',
+        provider: described_class.name,
       }
+    end
+
+    let(:resource) do
+      Puppet::Type.type(:openldap_overlay).new(params)
+    end
+
+    let(:provider) do
+      resource.provider
+    end
+
+    let(:tmpfile) { instance_spy(Tempfile) }
+    let(:tmpfile_path) { double }
+    let(:tmpfile_content) { double }
+
+    before do
+      allow(provider).to receive(:slapcat).and_return('foo')
+      allow(Tempfile).to receive(:new).and_return(tmpfile)
+      allow(tmpfile).to receive(:path).and_return(tmpfile_path)
+      allow(IO).to receive(:read).with(tmpfile_path).and_return(tmpfile_content)
+      allow(Puppet).to receive(:debug).with(tmpfile_content)
+      allow(provider).to receive(:getDn).and_return('dc=example,dc=com')
+      allow(provider).to receive(:ldapmodify)
     end
 
     describe 'when creating' do
       it 'creates an overlay' do
         provider.create
-        expect(tmpfile).to have_received(:<<).with("dn: olcOverlay=smbk5pwd,dc=example,dc=com\n")
-        expect(tmpfile).to have_received(:<<).with("objectClass: olcSmbK5PwdConfig\n")
-        expect(tmpfile).to have_received(:<<).with("olcOverlay: smbk5pwd\n")
-        expect(tmpfile).to have_received(:<<).with("olcSmbK5PwdEnable: samba\nolcSmbK5PwdEnable: shadow\n")
+        expect(tmpfile).to have_received(:<<).with("dn: olcOverlay=memberof,dc=example,dc=com\n")
+        expect(tmpfile).to have_received(:<<).with("objectClass: olcMemberOf\n")
+        expect(tmpfile).to have_received(:<<).with("olcOverlay: memberof\n")
         expect(provider).to have_received(:ldapmodify)
+      end
+    end
+
+    describe 'with smbk5pwd' do
+      let(:params) do
+        {
+          title: 'smbk5pwd on dc=example,dc=com',
+          options: {
+            'olcSmbK5PwdEnable' => %w[samba shadow],
+          },
+        }
+      end
+
+      describe 'when creating' do
+        it 'creates an overlay' do
+          provider.create
+          expect(tmpfile).to have_received(:<<).with("dn: olcOverlay=smbk5pwd,dc=example,dc=com\n")
+          expect(tmpfile).to have_received(:<<).with("objectClass: olcSmbK5PwdConfig\n")
+          expect(tmpfile).to have_received(:<<).with("olcOverlay: smbk5pwd\n")
+          expect(tmpfile).to have_received(:<<).with("olcSmbK5PwdEnable: samba\nolcSmbK5PwdEnable: shadow\n")
+          expect(provider).to have_received(:ldapmodify)
+        end
       end
     end
   end


### PR DESCRIPTION
#### This Pull Request (PR) fixes the following issues
Is a precursor to #431 (makes progress but does not solve the whole issue)

#### Pull Request (PR) description
4 parts to this PR:  
1. [boring] wraps the spec unit test for `openldap_overlay` in a new 'describe' layer (so we can isolate the existing 'create an overlay' test from new test).
2. [boring] remove an unused parameter from the unit test.
3. [cleanliness] add a 'does `.instances` work correctly"' test to `openldap_overlay`.  The current tests are "can we make a new overlay" but this adds a class of tests for "given slapcat of an existing deployment, do we detect+parse the overlay correctly?" - richer testing on existing behavior, and a framework for the next commit.
4. [the important commit] Add `olcChainConfig` and the ability to attach the overlay to the `frontend` pseudo-database, following a prior-art pattern from the `openldap_access` provider. ... and tests for adding/detecting the overlay.

#431 wants to add a Chain config, which is a two-part request: adding the Chain overlay, and then adding the database you're chaining TO.  However, that second part is more complex changes to `openldap_database`, and it's all dependent upon having this overlay in place first.  So while this isn't the complete solution I think there's enough in here to fold in (because if this gets rejected, the database work is of no value)