### PR TITLE
If the relay parameter is not set, the empty? errors out.

### DIFF
--- a/lib/puppet/provider/openldap_database/olc.rb
+++ b/lib/puppet/provider/openldap_database/olc.rb
@@ -232,7 +232,7 @@ Puppet::Type.
 
     case resource[:backend].to_s
     when 'relay'
-      t << "olcRelay: #{resource[:relay]}\n" unless resource[:relay].empty?
+      t << "olcRelay: #{resource[:relay]}\n" if resource[:relay]
       t << "olcSuffix: #{resource[:suffix]}\n" if resource[:suffix]
     when 'monitor'
       # WRITE HERE FOR MONITOR ONLY


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
When using the Openldap relay backend, not setting the relay parameter allows Openldap to use the database that matches the suffix.  The current ruby code checks if the relay parameter is empty, not if the key doesn't exist and thus errors if the key doesn't exist in the resources hash.
I have just modified that line to check for the relay key instead.
F.Y.I. If the key exists but is "empty", maybe a white space, there are other errors.
-->

#### This Pull Request (PR) fixes the following issues
<!--
n/a.
-->
