### PR TITLE
Also allow to have Sensitive[String[1]] for rootdn

### DIFF
--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -945,7 +945,7 @@ Default value: `undef`
 
 ##### <a name="-openldap--server--database--rootdn"></a>`rootdn`
 
-Data type: `Optional[String[1]]`
+Data type: `Optional[Variant[Sensitive[String[1]],String[1]]]`
 
 
 

--- a/manifests/server/database.pp
+++ b/manifests/server/database.pp
@@ -5,7 +5,7 @@ define openldap::server::database (
   String[1]                                           $suffix            = $title,
   Optional[String[1]]                                 $relay             = undef,
   Optional[String[1]]                                 $backend           = undef,
-  Optional[String[1]]                                 $rootdn            = undef,
+  Optional[Variant[Sensitive[String[1]],String[1]]]   $rootdn            = undef,
   Optional[Variant[Sensitive[String[1]],String[1]]]   $rootpw            = undef,
   Optional[Boolean]                                   $initdb            = undef,
   Boolean                                             $readonly          = false,

--- a/spec/defines/openldap_server_database_spec.rb
+++ b/spec/defines/openldap_server_database_spec.rb
@@ -23,6 +23,21 @@ describe 'openldap::server::database' do
             }
           end
 
+          context 'with sensitive parameters set' do
+            let(:params) do
+              {
+                rootdn: sensitive('cn=admin,dc=example,dc=com'),
+                rootpw: sensitive('secret'),
+              }
+            end
+
+            it { is_expected.to compile.with_all_deps }
+
+            it {
+              is_expected.to contain_openldap_database('dc=foo').with(rootdn: sensitive('cn=admin,dc=example,dc=com'), rootpw: sensitive('secret'))
+            }
+          end
+
           context 'with all parameters set' do
             let(:params) do
               {


### PR DESCRIPTION
#### Pull Request (PR) description
Currently only rootpw can be assigned as Sensitive, but in some cases one might want to keep the username (DN) out of the PuppetDB and the logs.

In our case, we use a secret lookup function that automatically wraps the data into a Sensitive type, and we store the DN and password together.


#### This Pull Request (PR) fixes the following issues
Not reported as an issue.
