### PR TITLE
Allow matchingRule and attrstyle in olcAccess

### DIFF
--- a/lib/puppet/provider/openldap_access/olc.rb
+++ b/lib/puppet/provider/openldap_access/olc.rb
@@ -30,7 +30,7 @@ Puppet::Type.
           suffix = line.split[1]
         when %r{^olcAccess: }
           begin
-            position, what, bys = line.match(%r{^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val=\S+)?)(\s+by\s+.*)+$}).captures
+            position, what, bys = line.match(%r{^olcAccess:\s+\{(\d+)\}to\s+(\S+(?:\s+filter=\S+)?(?:\s+attrs=\S+)?(?:\s+val(?:/\S+)?(?:\.\S+)?=\S+)?)(\s+by\s+.*)+$}).captures
           rescue StandardError
             raise Puppet::Error, "Failed to parse olcAccess for suffix '#{suffix}': #{line}"
           end


### PR DESCRIPTION
We had a requirement to use a diffent matchingRule for the Access Rule. This inported well but on the next run it did fail because it could not parse it. This fixes this

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
<!--
Replace this comment with a description of your pull request.
-->

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
